### PR TITLE
implement tests for blst introductions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blst"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,10 +157,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -145,9 +202,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "kzg_poly_commit_exploration"
 version = "0.1.0"
 dependencies = [
+ "blst",
  "clap",
  "dotenvy",
  "log",
+ "rand",
  "simple_logger",
 ]
 
@@ -176,6 +235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +290,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -233,6 +346,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple_logger"
@@ -261,6 +380,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -307,6 +435,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -446,3 +583,52 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
 name = "blst"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,12 +72,6 @@ checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -157,18 +145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,7 +182,6 @@ dependencies = [
  "clap",
  "dotenvy",
  "log",
- "rand",
  "simple_logger",
 ]
 
@@ -266,15 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,41 +256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -435,15 +366,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
 
 [[package]]
 name = "windows-sys"
@@ -583,35 +505,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ blst = "0.3.15"
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
-rand = "0.9.1"
 simple_logger = "5.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+blst = "0.3.15"
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
+rand = "0.9.1"
 simple_logger = "5.0.0"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This whole part is way heavier than what I described here, I tried my best to su
 In terms of implementations, the book of Ben Edington refers to multiple resources, for now I am still exploring a bit the ones that may be compatible for Rust:
 - [blst](https://crates.io/crates/blst): provides a simple API for BLS signature, not sure it could handle my simple trusted setup plan,
 - [constantine](https://github.com/mratsim/constantine): not sure yet how to use this one,
-- [blsh](https://github.com/one-hundred-proof/blsh): seems promising to play around.
+- [blsh](https://github.com/one-hundred-proof/blsh): seems promising to play around,
+- [algebra](https://github.com/arkworks-rs/algebra): I discovered it a bit later, I have not tried it yet.
 
 #### Library choice
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ I got what I needed in two tests:
 #[cfg(test)]
 mod tests {
     #[test]
-    fn operations() {
+    fn test_point_addition_and_scalar_multiplication() {
         unsafe {
             let g1 = blst::blst_p1_generator();
 
@@ -89,7 +89,7 @@ mod tests {
     }
 
     #[test]
-    fn compressions() {
+    fn test_compression_and_serialization() {
         unsafe {
             let g1 = blst::blst_p1_generator();
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ mod tests {
             blst::blst_p1_add_or_double(&mut p1_via_addition, g1, g1);
 
             let mut p1_via_multiplication = blst::blst_p1::default();
+            let scalar_as_bytes = 2_u8.to_be_bytes();
             blst::blst_p1_mult(
                 &mut p1_via_multiplication,
                 g1,
-                2_u8.to_be_bytes().as_ptr(),
-                255,
+                scalar_as_bytes.as_ptr(),
+                scalar_as_bytes.len() * 8,
             );
 
             assert!(blst::blst_p1_in_g1(g1), "g1 must be in the first group");
@@ -132,7 +133,6 @@ mod tests {
         }
     }
 }
-
 ```
 
 ## Repository setup

--- a/README.md
+++ b/README.md
@@ -39,6 +39,101 @@ In terms of implementations, the book of Ben Edington refers to multiple resourc
 - [constantine](https://github.com/mratsim/constantine): not sure yet how to use this one,
 - [blsh](https://github.com/one-hundred-proof/blsh): seems promising to play around.
 
+#### Library choice
+
+I finally dig in `blst`, I was also looking at `blsh` codebase to see how it was using the `blst` library.
+
+The library is mostly made for dealing with BLS signatures but still exposes low levels utilities in order to work with the elliptic curve groups and the finite field groups. 
+
+It took me some time to have something working as the library does not have a very good documentation and my understanding of the different formats was not on point. I had to read a good amount of times the serialization conventions from [ZCash](https://github.com/zcash/librustzcash/blob/6e0364cd42a2b3d2b958a54771ef51a8db79dd29/pairing/src/bls12_381/README.md#serialization) and [Ben Edington's book](https://eth2book.info/capella/part2/building_blocks/bls12-381/#point-compression) in order to understand the compression and serialization utilities from the library. The [explanation](https://eth2book.info/capella/part2/building_blocks/bls12-381/#coordinate-systems) for the various coordinate systems are also a must read.
+
+I got what I needed in two tests:
+- one for operations where I test addition of two points and addition of one point `n` times,
+- one for testing compression and serialization.
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn operations() {
+        unsafe {
+            let g1 = blst::blst_p1_generator();
+
+            let mut p1_via_addition = blst::blst_p1::default();
+            blst::blst_p1_add_or_double(&mut p1_via_addition, g1, g1);
+
+            let mut p1_via_multiplication = blst::blst_p1::default();
+            blst::blst_p1_mult(
+                &mut p1_via_multiplication,
+                g1,
+                2_u8.to_be_bytes().as_ptr(),
+                255,
+            );
+
+            assert!(blst::blst_p1_in_g1(g1), "g1 must be in the first group");
+            assert_eq!(
+                p1_via_multiplication, p1_via_addition,
+                "results must be the same via multiplication and via addition"
+            );
+            assert_ne!(
+                p1_via_multiplication, *g1,
+                "result must be different than g1"
+            );
+            assert!(
+                blst::blst_p1_in_g1(&p1_via_multiplication),
+                "result must be in first group"
+            );
+        }
+    }
+
+    #[test]
+    fn compressions() {
+        unsafe {
+            let g1 = blst::blst_p1_generator();
+
+            let mut p1 = blst::blst_p1::default();
+            blst::blst_p1_add_or_double(&mut p1, g1, g1);
+
+            let mut compressed_p1 = [0; 48];
+            blst::blst_p1_compress(compressed_p1.as_mut_ptr(), &p1);
+            let mut uncompressed_p1_affine = blst::blst_p1_affine::default();
+            match blst::blst_p1_uncompress(&mut uncompressed_p1_affine, compressed_p1.as_ptr()) {
+                blst::BLST_ERROR::BLST_SUCCESS => {}
+                other => {
+                    println!("Got error while uncompressing: {other:?}");
+                    panic!("Fail to uncompress")
+                }
+            };
+            let mut uncompressed_p1 = blst::blst_p1::default();
+            blst::blst_p1_from_affine(&mut uncompressed_p1, &uncompressed_p1_affine);
+            assert_eq!(
+                uncompressed_p1, p1,
+                "result after uncompression must be equal to p1"
+            );
+
+            let mut serialized_p1 = [0; 96];
+            blst::blst_p1_serialize(serialized_p1.as_mut_ptr(), &p1);
+            let mut deserialized_p1_affine = blst::blst_p1_affine::default();
+            match blst::blst_p1_deserialize(&mut deserialized_p1_affine, serialized_p1.as_ptr()) {
+                blst::BLST_ERROR::BLST_SUCCESS => {}
+                other => {
+                    println!("Got error while deserializing: {other:?}",);
+                    panic!("Fail to deserialize")
+                }
+            };
+
+            let mut deserialized_p1 = blst::blst_p1::default();
+            blst::blst_p1_from_affine(&mut deserialized_p1, &deserialized_p1_affine);
+            assert_eq!(
+                deserialized_p1, p1,
+                "result after deserialization must be equal to p1"
+            );
+        }
+    }
+}
+
+```
+
 ## Repository setup
 
 Environment variables can be set up using `.env` file at the root of the repository, see `.env.example` for a list of the supported environment variables.

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn operations() {
+    fn test_point_addition_and_scalar_multiplication() {
         unsafe {
             let g1 = blst::blst_p1_generator();
 
@@ -88,7 +88,7 @@ mod tests {
     }
 
     #[test]
-    fn compressions() {
+    fn test_compression_and_serialization() {
         unsafe {
             let g1 = blst::blst_p1_generator();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,13 +63,12 @@ mod tests {
             blst::blst_p1_add_or_double(&mut p1_via_addition, g1, g1);
 
             let mut p1_via_multiplication = blst::blst_p1::default();
-            let scalar = 2_u8.to_be_bytes();
-            println!("{scalar:?}, length: {}", scalar.len());
+            let scalar_as_bytes = 2_u8.to_be_bytes();
             blst::blst_p1_mult(
                 &mut p1_via_multiplication,
                 g1,
-                scalar.as_ptr(),
-                2, // Only two for the bits representation of `2`
+                scalar_as_bytes.as_ptr(),
+                scalar_as_bytes.len() * 8,
             );
 
             assert!(blst::blst_p1_in_g1(g1), "g1 must be in the first group");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
-use std::str::FromStr;
-
 use clap::{Parser, Subcommand};
+use std::str::FromStr;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -49,6 +48,86 @@ fn main() {
         }
         None => {
             log::warn!("No command has been input")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn operations() {
+        unsafe {
+            let g1 = blst::blst_p1_generator();
+
+            let mut p1_via_addition = blst::blst_p1::default();
+            blst::blst_p1_add_or_double(&mut p1_via_addition, g1, g1);
+
+            let mut p1_via_multiplication = blst::blst_p1::default();
+            blst::blst_p1_mult(
+                &mut p1_via_multiplication,
+                g1,
+                2_u8.to_be_bytes().as_ptr(),
+                255,
+            );
+
+            assert!(blst::blst_p1_in_g1(g1), "g1 must be in the first group");
+            assert_eq!(
+                p1_via_multiplication, p1_via_addition,
+                "results must be the same via multiplication and via addition"
+            );
+            assert_ne!(
+                p1_via_multiplication, *g1,
+                "result must be different than g1"
+            );
+            assert!(
+                blst::blst_p1_in_g1(&p1_via_multiplication),
+                "result must be in first group"
+            );
+        }
+    }
+
+    #[test]
+    fn compressions() {
+        unsafe {
+            let g1 = blst::blst_p1_generator();
+
+            let mut p1 = blst::blst_p1::default();
+            blst::blst_p1_add_or_double(&mut p1, g1, g1);
+
+            let mut compressed_p1 = [0; 48];
+            blst::blst_p1_compress(compressed_p1.as_mut_ptr(), &p1);
+            let mut uncompressed_p1_affine = blst::blst_p1_affine::default();
+            match blst::blst_p1_uncompress(&mut uncompressed_p1_affine, compressed_p1.as_ptr()) {
+                blst::BLST_ERROR::BLST_SUCCESS => {}
+                other => {
+                    println!("Got error while uncompressing: {other:?}");
+                    panic!("Fail to uncompress")
+                }
+            };
+            let mut uncompressed_p1 = blst::blst_p1::default();
+            blst::blst_p1_from_affine(&mut uncompressed_p1, &uncompressed_p1_affine);
+            assert_eq!(
+                uncompressed_p1, p1,
+                "result after uncompression must be equal to p1"
+            );
+
+            let mut serialized_p1 = [0; 96];
+            blst::blst_p1_serialize(serialized_p1.as_mut_ptr(), &p1);
+            let mut deserialized_p1_affine = blst::blst_p1_affine::default();
+            match blst::blst_p1_deserialize(&mut deserialized_p1_affine, serialized_p1.as_ptr()) {
+                blst::BLST_ERROR::BLST_SUCCESS => {}
+                other => {
+                    println!("Got error while deserializing: {other:?}",);
+                    panic!("Fail to deserialize")
+                }
+            };
+
+            let mut deserialized_p1 = blst::blst_p1::default();
+            blst::blst_p1_from_affine(&mut deserialized_p1, &deserialized_p1_affine);
+            assert_eq!(
+                deserialized_p1, p1,
+                "result after deserialization must be equal to p1"
+            );
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,11 +63,13 @@ mod tests {
             blst::blst_p1_add_or_double(&mut p1_via_addition, g1, g1);
 
             let mut p1_via_multiplication = blst::blst_p1::default();
+            let scalar = 2_u8.to_be_bytes();
+            println!("{scalar:?}, length: {}", scalar.len());
             blst::blst_p1_mult(
                 &mut p1_via_multiplication,
                 g1,
-                2_u8.to_be_bytes().as_ptr(),
-                255,
+                scalar.as_ptr(),
+                2, // Only two for the bits representation of `2`
             );
 
             assert!(blst::blst_p1_in_g1(g1), "g1 must be in the first group");


### PR DESCRIPTION
## Summary

Two tests are written in order to discover the [blst](https://github.com/supranational/blst) crate. The tests are manipulating only points on the first elliptic curve group for `BLS12-381` construction.

- One test for playing with addition of two points and addition of one point `n` times,
- another test for playing with compression/uncompression and serialization/deserialization of a point.

