### PR TITLE
Implement tests for simple polynomial commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "blst"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,12 @@ checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -145,6 +157,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +206,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "log",
+ "rand",
  "simple_logger",
 ]
 
@@ -241,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +290,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -366,6 +435,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -505,6 +583,35 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +212,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "log",
+ "num-bigint",
  "rand",
  "simple_logger",
 ]
@@ -229,10 +236,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ blst = "0.3.15"
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
+num-bigint = "0.4.6"
 rand = "0.9.1"
 simple_logger = "5.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ blst = "0.3.15"
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
+rand = "0.9.1"
 simple_logger = "5.0.0"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ I wanted to write my trusted setup script but I liked my first approach with tes
 6. compute the remaining quantities and the two pairings,
 7. compare the pairings, they must be equal.
 
-Not gonna lie, it took me some time to make it work. I discovered a lot about bytes in general, in particular the difference between [low endian and big endian](https://www.techtarget.com/searchnetworking/definition/big-endian-and-little-endian). There are still some things that are not perfectly clear for me, like the `scalar` type of the `blst` crate, I will try to understand it a bit better. However, it allowed me to illustrate concretly the KZG polynomial commitment process and I'm quite happy to have this working.
+Not gonna lie, it took me some time to make it work. I discovered a lot about bytes in general, in particular the difference between [little endian and big endian](https://www.techtarget.com/searchnetworking/definition/big-endian-and-little-endian). There are still some things that are not perfectly clear for me, like the `scalar` type of the `blst` crate, I will try to understand it a bit better. However, it allowed me to illustrate concretely the KZG polynomial commitment process and I'm quite happy to have this working.
 
 Here is the test made for the order one polynomial:
 ```rust

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ fn test_commitment_for_polynomial_degree_one() {
             &mut y,
             blst::blst_p1_generator(),
             y_as_scalar.b.as_ptr(),
-            y_as_scalar.b.len(),
+            y_as_scalar.b.len() * 8,
         );
     };
     let commitment_part = blst_p1_sub(&commitment, &y);

--- a/README.md
+++ b/README.md
@@ -135,6 +135,107 @@ mod tests {
 }
 ```
 
+#### Digging until I got tests for polynomial commitments
+
+I wanted to write my trusted setup script but I liked my first approach with test. So I took the time to write two more tests for polynomial commitments without smart things and with simple polynomials. I did one test for order 1 polynomial, the other is for order 2 polynomial. The approach is the same in both tests:
+1. start by generating a secret,
+2. the secret is used in order to compute the multiple of the generators of the first and second group,
+3. use these quantities in order to compute the polynomial commitment,
+4. choose a point at which we want to open the polynomial and derive the quotient polynomial manually (non automated),
+5. evaluate the quotient polynomial at the secret using the artifacts of step 2,
+6. compute the remaining quantities and the two pairings,
+7. compare the pairings, they must be equal.
+
+Not gonna lie, it took me some time to make it work. I discovered a lot about bytes in general, in particular the difference between [low endian and big endian](https://www.techtarget.com/searchnetworking/definition/big-endian-and-little-endian). There are still some things that are not perfectly clear for me, like the `scalar` type of the `blst` crate, I will try to understand it a bit better. However, it allowed me to illustrate concretly the KZG polynomial commitment process and I'm quite happy to have this working.
+
+Here is the test made for the order one polynomial:
+```rust
+#[test]
+fn test_commitment_for_polynomial_degree_one() {
+    let mut s_bytes = [0; 48]; // Field elements are encoded in big endian form with 48 bytes
+    rand::rng().fill_bytes(&mut s_bytes);
+    let mut s_as_scalar = blst::blst_scalar::default();
+    unsafe {
+        blst::blst_scalar_from_be_bytes(&mut s_as_scalar, s_bytes.as_ptr(), s_bytes.len());
+    };
+
+    let mut s_g1 = blst::blst_p1::default();
+    unsafe {
+        blst::blst_p1_mult(
+            &mut s_g1,
+            blst::blst_p1_generator(),
+            s_as_scalar.b.as_ptr(),
+            s_as_scalar.b.len() * 8,
+        );
+    };
+    let mut s_g2 = blst::blst_p2::default();
+    unsafe {
+        blst::blst_p2_mult(
+            &mut s_g2,
+            blst::blst_p2_generator(),
+            s_as_scalar.b.as_ptr(),
+            s_as_scalar.b.len() * 8,
+        );
+    };
+
+    // Polynomial to commit is `p(x) = 5x + 10
+    // a1 = 5, a0 = 10`
+    let a0 = blst_scalar_from_u8(10);
+    let mut constant_part = blst::blst_p1::default();
+    unsafe {
+        blst::blst_p1_mult(
+            &mut constant_part,
+            blst::blst_p1_generator(),
+            a0.b.as_ptr(),
+            a0.b.len() * 8,
+        );
+    };
+
+    let a1 = blst_scalar_from_u8(5);
+    let mut order_one_part = blst::blst_p1::default();
+    unsafe {
+        blst::blst_p1_mult(&mut order_one_part, &s_g1, a1.b.as_ptr(), a1.b.len() * 8);
+    };
+    let mut commitment = blst::blst_p1::default();
+    unsafe {
+        blst::blst_p1_add_or_double(&mut commitment, &constant_part, &order_one_part);
+    };
+
+    // We evaluate the polynomial at z = 1: `p(z) = y = p(1) = 15`
+    // Quotient polynomial: `q(x) = (p(x) - y) / (x - z) = (5x - 5) / (x - 1) = 5`
+    let q_as_scalar = blst_scalar_from_u8(5);
+    let mut q_at_s = blst::blst_p1::default();
+    unsafe {
+        blst::blst_p1_mult(
+            &mut q_at_s,
+            blst::blst_p1_generator(),
+            q_as_scalar.b.as_ptr(),
+            q_as_scalar.b.len() * 8,
+        );
+    };
+
+    let z = unsafe { *blst::blst_p2_generator() };
+    let divider = blst_p2_sub(&s_g2, &z);
+    let lhs = bilinear_map(&q_at_s, &divider);
+
+    let y_as_scalar = blst_scalar_from_u8(15);
+    let mut y = blst::blst_p1::default();
+    unsafe {
+        blst::blst_p1_mult(
+            &mut y,
+            blst::blst_p1_generator(),
+            y_as_scalar.b.as_ptr(),
+            y_as_scalar.b.len(),
+        );
+    };
+    let commitment_part = blst_p1_sub(&commitment, &y);
+    let g2 = unsafe { *blst::blst_p2_generator() };
+    let rhs = bilinear_map(&commitment_part, &g2);
+
+    assert_eq!(lhs, rhs);
+}
+```
+
 ## Repository setup
 
 Environment variables can be set up using `.env` file at the root of the repository, see `.env.example` for a list of the supported environment variables.

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,10 +276,6 @@ mod tests {
     fn test_commitment_for_polynomial_degree_two() {
         let mut s_bytes = [0; 48]; // Field elements are encoded in big endian form with 48 bytes
         rand::rng().fill_bytes(&mut s_bytes);
-        let mut s = blst::blst_fp::default();
-        unsafe {
-            blst::blst_fp_from_lendian(&mut s, s_bytes.as_ptr());
-        };
         let s_as_buint = BigUint::from_bytes_be(&s_bytes);
 
         let mut s_as_scalar = blst::blst_scalar::default();
@@ -350,7 +346,7 @@ mod tests {
         let a1 = blst_scalar_from_u8(3);
         let mut order_one_part = blst::blst_p1::default();
         unsafe {
-            blst::blst_p1_mult(&mut order_one_part, &s_g1, a1.b.as_ptr(), a1.b.len());
+            blst::blst_p1_mult(&mut order_one_part, &s_g1, a1.b.as_ptr(), a1.b.len() * 8);
         };
         let a2 = blst_scalar_from_u8(2);
         let mut order_two_part = blst::blst_p1::default();
@@ -359,7 +355,7 @@ mod tests {
                 &mut order_two_part,
                 &s_squared_g1,
                 a2.b.as_ptr(),
-                a2.b.len(),
+                a2.b.len() * 8,
             );
         };
         let mut commitment = blst::blst_p1::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ mod tests {
                 &mut y,
                 blst::blst_p1_generator(),
                 y_as_scalar.b.as_ptr(),
-                y_as_scalar.b.len(),
+                y_as_scalar.b.len() * 8,
             );
         };
         let commitment_part = blst_p1_sub(&commitment, &y);


### PR DESCRIPTION
## Summary

Two additional tests are added in order to play with the `blst` crate. These two tests are an implementation of KZG polynomial commitments:
- one for order one polynomial,
- one for order two polynomial.
