### PR TITLE
output trusted setup in a .json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ fn test_commitment_for_polynomial_degree_one() {
 I want to add a new command in order to execute the trusted setup ceremony, it will look a bit like what has been done in the tests in my previous step but in a more constructed way:
 - a random field element `s` is generated,
 - the `s` is used in order to generate the points `s^k & G, k = 0 .. N` on the two elliptic curves using their generator `G`,
-- the points are written in a file `./artifacts/setup.txt`.
+- the points are written in a file `./artifacts/setup.json`.
 
 > [!CAUTION]
 > Do not use this setup for any production use, it is made for testing purpose only.

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Perform a trusted setup ceremony.
-    /// The generated artifacts are written in `./artifacts/setup.txt`.
-    /// The artifacts are generated up until the degree 9.
+    /// Perform a trusted setup ceremony and write the artifacts in './artifacts/setup.json'. Artifacts are genetated until degree 9.
     TrustedSetup {},
-    /// Print "Hello, world!"
-    HelloWorld {},
 }
 
 fn main() {
@@ -85,7 +81,7 @@ impl Commands {
                 log::info!("Starting the trusted setup ceremony");
 
                 let artifacts_folder_path = "./artifacts";
-                let setup_artifacts_path = format!("{artifacts_folder_path}/setup.txt");
+                let setup_artifacts_path = format!("{artifacts_folder_path}/setup.json");
                 if !fs::exists(artifacts_folder_path)? {
                     fs::create_dir(artifacts_folder_path)?;
                 }
@@ -112,10 +108,6 @@ impl Commands {
                     "Trusted setup ceremony successfully performed. Artifacts have been written in \"{setup_artifacts_path}\""
                 );
 
-                Ok(())
-            }
-            Commands::HelloWorld {} => {
-                log::info!("Hello, world!");
                 Ok(())
             }
         }


### PR DESCRIPTION
## Summary

The trusted setup file artifacts is now `setup.json` instead of `setup.txt`.

The `hello-world` command has been removed.
