### PR TITLE
Implement polynomial commitment command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "kzg_poly_commit_exploration"
 version = "0.1.0"
 edition = "2024"
+description = "A command line parser in order to play with KZG polynomial commitment"
+readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.98"

--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ The generation of `s` is simply made using a basic `fill_bytes` with the default
 > [!NOTE]
 > Serialization is made using [serde](https://serde.rs/). The serialization is implemented by first compressing the group element and then serializing the byte array. Deserialization is implemented using the other way around.
 
+### Polynomial commitment
+
+Now that we have the artifacts of the trusted setup, we can implement the commitment part. The plan will be to add a new command such that:
+- it receives as input the polynomial coefficients,
+- it retrieves the trusted setup artifacts,
+- it computes the polynomial commitment and generate a new artifact with the polynomial and the associated commitment.
+
 ## Repository setup
 
 Environment variables can be set up using `.env` file at the root of the repository, see `.env.example` for a list of the supported environment variables.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ mod tests {
 
 #### Digging until I got tests for polynomial commitments
 
-I wanted to write my trusted setup script but I liked my first approach with test. So I took the time to write two more tests for polynomial commitments without smart things and with simple polynomials. I did one test for order 1 polynomial, the other is for order 2 polynomial. The approach is the same in both tests:
+I wanted to write my trusted setup script but I liked my first approach with test. So I took the time to write two more tests for polynomial commitments without smart things and with simple polynomials. I did one test for degree 1 polynomial, the other is for degree 2 polynomial. The approach is the same in both tests:
 1. start by generating a secret,
 2. the secret is used in order to compute the multiple of the generators of the first and second group,
 3. use these quantities in order to compute the polynomial commitment,
@@ -148,7 +148,7 @@ I wanted to write my trusted setup script but I liked my first approach with tes
 
 Not gonna lie, it took me some time to make it work. I discovered a lot about bytes in general, in particular the difference between [little endian and big endian](https://www.techtarget.com/searchnetworking/definition/big-endian-and-little-endian). There are still some things that are not perfectly clear for me, like the `scalar` type of the `blst` crate, I will try to understand it a bit better. However, it allowed me to illustrate concretely the KZG polynomial commitment process and I'm quite happy to have this working.
 
-Here is the test made for the order one polynomial:
+Here is the test made for the degree one polynomial:
 ```rust
 #[test]
 fn test_commitment_for_polynomial_degree_one() {
@@ -192,13 +192,13 @@ fn test_commitment_for_polynomial_degree_one() {
     };
 
     let a1 = blst_scalar_from_u8(5);
-    let mut order_one_part = blst::blst_p1::default();
+    let mut degree_one_part = blst::blst_p1::default();
     unsafe {
-        blst::blst_p1_mult(&mut order_one_part, &s_g1, a1.b.as_ptr(), a1.b.len() * 8);
+        blst::blst_p1_mult(&mut degree_one_part, &s_g1, a1.b.as_ptr(), a1.b.len() * 8);
     };
     let mut commitment = blst::blst_p1::default();
     unsafe {
-        blst::blst_p1_add_or_double(&mut commitment, &constant_part, &order_one_part);
+        blst::blst_p1_add_or_double(&mut commitment, &constant_part, &degree_one_part);
     };
 
     // We evaluate the polynomial at z = 1: `p(z) = y = p(1) = 15`

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -1,0 +1,222 @@
+use std::ops::Deref;
+
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Visitor},
+};
+
+#[derive(Debug)]
+pub struct G1Point(blst::blst_p1);
+
+impl Deref for G1Point {
+    type Target = blst::blst_p1;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<blst::blst_p1> for G1Point {
+    fn from(value: blst::blst_p1) -> Self {
+        G1Point(value)
+    }
+}
+
+impl G1Point {
+    pub fn as_raw_ptr(&self) -> *const blst::blst_p1 {
+        &self.0
+    }
+}
+
+impl Serialize for G1Point {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut compressed_p1 = [0; 48];
+        unsafe {
+            blst::blst_p1_compress(compressed_p1.as_mut_ptr(), self.as_raw_ptr());
+        };
+        serializer.serialize_bytes(&compressed_p1)
+    }
+}
+
+impl<'de> Deserialize<'de> for G1Point {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct G1PointVisitor;
+
+        fn bytes_to_blst_p1(v: &[u8]) -> Result<G1Point, anyhow::Error> {
+            if v.len() != 48 {
+                return Err(anyhow::anyhow!(
+                    "Invalid length, expected 48, got {}",
+                    v.len()
+                ));
+            }
+
+            let mut compressed_p1 = [0u8; 48];
+            compressed_p1.copy_from_slice(v);
+            let mut uncompressed_p1_affine = blst::blst_p1_affine::default();
+            unsafe {
+                match blst::blst_p1_uncompress(&mut uncompressed_p1_affine, compressed_p1.as_ptr())
+                {
+                    blst::BLST_ERROR::BLST_SUCCESS => Ok(()),
+                    other => Err(other),
+                }
+            }
+            .map_err(|err| anyhow::anyhow!("Got error while uncompressing: {err:?}"))?;
+
+            let mut uncompressed_p1 = blst::blst_p1::default();
+            unsafe {
+                blst::blst_p1_from_affine(&mut uncompressed_p1, &uncompressed_p1_affine);
+            };
+            Ok(uncompressed_p1.into())
+        }
+
+        impl<'de> Visitor<'de> for G1PointVisitor {
+            type Value = G1Point;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("Sequence of u8")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let mut elements: Vec<u8> = vec![];
+
+                while let Some(a) = seq.next_element()? {
+                    elements.push(a)
+                }
+
+                bytes_to_blst_p1(&elements).map_err(de::Error::custom)
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                bytes_to_blst_p1(v).map_err(de::Error::custom)
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                bytes_to_blst_p1(v).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_seq(G1PointVisitor)
+    }
+}
+
+#[derive(Debug)]
+pub struct G2Point(blst::blst_p2);
+
+impl From<blst::blst_p2> for G2Point {
+    fn from(value: blst::blst_p2) -> Self {
+        G2Point(value)
+    }
+}
+
+impl G2Point {
+    pub fn as_raw_ptr(&self) -> *const blst::blst_p2 {
+        &self.0
+    }
+}
+
+impl Deref for G2Point {
+    type Target = blst::blst_p2;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for G2Point {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut compressed_p2 = [0; 96];
+        unsafe {
+            blst::blst_p2_compress(compressed_p2.as_mut_ptr(), self.as_raw_ptr());
+        };
+        serializer.serialize_bytes(&compressed_p2)
+    }
+}
+
+impl<'de> Deserialize<'de> for G2Point {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct G2PointVisitor;
+
+        fn bytes_to_blst_p2(v: &[u8]) -> Result<G2Point, anyhow::Error> {
+            if v.len() != 96 {
+                return Err(anyhow::anyhow!(
+                    "Invalid length, expected 96, got {}",
+                    v.len()
+                ));
+            }
+
+            let mut compressed_p2 = [0u8; 96];
+            compressed_p2.copy_from_slice(v);
+            let mut uncompressed_p2_affine = blst::blst_p2_affine::default();
+            unsafe {
+                match blst::blst_p2_uncompress(&mut uncompressed_p2_affine, compressed_p2.as_ptr())
+                {
+                    blst::BLST_ERROR::BLST_SUCCESS => Ok(()),
+                    other => Err(other),
+                }
+            }
+            .map_err(|err| anyhow::anyhow!("Got error while uncompressing: {err:?}"))?;
+
+            let mut uncompressed_p2 = blst::blst_p2::default();
+            unsafe {
+                blst::blst_p2_from_affine(&mut uncompressed_p2, &uncompressed_p2_affine);
+            };
+            Ok(uncompressed_p2.into())
+        }
+
+        impl<'de> Visitor<'de> for G2PointVisitor {
+            type Value = G2Point;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("Sequence of u8")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let mut elements: Vec<u8> = vec![];
+
+                while let Some(a) = seq.next_element()? {
+                    elements.push(a)
+                }
+
+                bytes_to_blst_p2(&elements).map_err(de::Error::custom)
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                bytes_to_blst_p2(v).map_err(de::Error::custom)
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                bytes_to_blst_p2(v).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_bytes(G2PointVisitor)
+    }
+}

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -217,6 +217,6 @@ impl<'de> Deserialize<'de> for G2Point {
             }
         }
 
-        deserializer.deserialize_bytes(G2PointVisitor)
+        deserializer.deserialize_seq(G2PointVisitor)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,9 @@ impl Commands {
                     );
                 }
 
-                log::info!("Starting to commit to the polynomial P(x) = \"{polynomial_displayed}\"");
+                log::info!(
+                    "Starting to commit to the polynomial P(x) = \"{polynomial_displayed}\""
+                );
 
                 if !fs::exists(SETUP_ARTIFACTS_FOLDER_PATH)? {
                     return Err(anyhow::anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,13 +131,15 @@ impl Commands {
             Commands::Commit { coefficients } => {
                 let polynomial = polynomial::Polynomial::from(coefficients.as_slice());
 
+                let polynomial_displayed = polynomial.to_string();
+
                 if polynomial.order() > usize::from(MAX_DEGREE) {
                     return Err(
                         anyhow::anyhow!("Only polynomials up to 9 decimals are supported").into(),
                     );
                 }
 
-                log::info!("Starting to commit to the polynomial P(x) = {polynomial}");
+                log::info!("Starting to commit to the polynomial P(x) = \"{polynomial_displayed}\"");
 
                 if !fs::exists(SETUP_ARTIFACTS_FOLDER_PATH)? {
                     return Err(anyhow::anyhow!(
@@ -167,7 +169,7 @@ impl Commands {
                 file.write_all(commitment_artifact.as_bytes())?;
 
                 log::info!(
-                    "Commitment to the polynomial \"P(x) = 5x + 3\" has been successfully generated."
+                    "Commitment to the polynomial \"P(x) = {polynomial_displayed}\" has been successfully generated."
                 );
 
                 Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,9 @@ enum Commands {
     TrustedSetup {},
     /// Commit to a polynomial using the trusted setup artifacts
     Commit {
-        /// Coefficients of the polynomial in ascending order, starting from the order zero.
+        /// Coefficients of the polynomial in ascending degree, starting from the degree zero.
         ///
-        /// Order up to 9 is supported.
+        /// Degree up to 9 is supported.
         #[arg(long_help, num_args = 1..)]
         coefficients: Vec<i8>,
     },
@@ -133,9 +133,9 @@ impl Commands {
 
                 let polynomial_displayed = polynomial.to_string();
 
-                if polynomial.order() > usize::from(MAX_DEGREE) {
+                if polynomial.degree() > usize::from(MAX_DEGREE) {
                     return Err(
-                        anyhow::anyhow!("Only polynomials up to order 9 are supported").into(),
+                        anyhow::anyhow!("Only polynomials up to degree 9 are supported").into(),
                     );
                 }
 
@@ -384,10 +384,10 @@ mod tests {
             );
         };
         let b1 = blst_scalar_from_i8_as_abs(2);
-        let mut q_at_s_order_one_part = blst::blst_p1::default();
+        let mut q_at_s_degree_one_part = blst::blst_p1::default();
         unsafe {
             blst::blst_p1_mult(
-                &mut q_at_s_order_one_part,
+                &mut q_at_s_degree_one_part,
                 setup_artifacts[1].g1.as_raw_ptr(),
                 b1.b.as_ptr(),
                 b1.b.len() * 8,
@@ -395,7 +395,7 @@ mod tests {
         };
         let mut q_at_s = blst::blst_p1::default();
         unsafe {
-            blst::blst_p1_add_or_double(&mut q_at_s, &q_at_s_constant_part, &q_at_s_order_one_part);
+            blst::blst_p1_add_or_double(&mut q_at_s, &q_at_s_constant_part, &q_at_s_degree_one_part);
         }
 
         let z_as_scalar = blst_scalar_from_i8_as_abs(2);
@@ -452,10 +452,10 @@ mod tests {
             );
         };
         let b1 = blst_scalar_from_i8_as_abs(2);
-        let mut q_at_s_order_one_part = blst::blst_p1::default();
+        let mut q_at_s_degree_one_part = blst::blst_p1::default();
         unsafe {
             blst::blst_p1_mult(
-                &mut q_at_s_order_one_part,
+                &mut q_at_s_degree_one_part,
                 setup_artifacts[1].g1.as_raw_ptr(),
                 b1.b.as_ptr(),
                 b1.b.len() * 8,
@@ -463,7 +463,7 @@ mod tests {
         };
         let mut q_at_s = blst::blst_p1::default();
         unsafe {
-            blst::blst_p1_add_or_double(&mut q_at_s, &q_at_s_constant_part, &q_at_s_order_one_part);
+            blst::blst_p1_add_or_double(&mut q_at_s, &q_at_s_constant_part, &q_at_s_degree_one_part);
         }
 
         let z_as_scalar = blst_scalar_from_i8_as_abs(2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ impl Commands {
                 log::info!("Starting the trusted setup ceremony");
 
                 if !fs::exists(ARTIFACTS_FOLDER_PATH)? {
-                    fs::create_dir(SETUP_ARTIFACTS_FOLDER_PATH)?;
+                    fs::create_dir(ARTIFACTS_FOLDER_PATH)?;
                 }
                 if fs::exists(SETUP_ARTIFACTS_FOLDER_PATH)? {
                     fs::remove_file(SETUP_ARTIFACTS_FOLDER_PATH)?;
@@ -135,7 +135,7 @@ impl Commands {
 
                 if polynomial.order() > usize::from(MAX_DEGREE) {
                     return Err(
-                        anyhow::anyhow!("Only polynomials up to 9 decimals are supported").into(),
+                        anyhow::anyhow!("Only polynomials up to order 9 are supported").into(),
                     );
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ impl Commands {
 
                 let setup_artifacts: Vec<_> =
                     trusted_setup::SetupArtifactsGenerator::new(s_be_bytes)
-                        .take(usize::from(MAX_DEGREE))
+                        .take(usize::from(MAX_DEGREE + 1))
                         .collect();
 
                 let stringified_artifacts =

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,7 +395,11 @@ mod tests {
         };
         let mut q_at_s = blst::blst_p1::default();
         unsafe {
-            blst::blst_p1_add_or_double(&mut q_at_s, &q_at_s_constant_part, &q_at_s_degree_one_part);
+            blst::blst_p1_add_or_double(
+                &mut q_at_s,
+                &q_at_s_constant_part,
+                &q_at_s_degree_one_part,
+            );
         }
 
         let z_as_scalar = blst_scalar_from_i8_as_abs(2);
@@ -463,7 +467,11 @@ mod tests {
         };
         let mut q_at_s = blst::blst_p1::default();
         unsafe {
-            blst::blst_p1_add_or_double(&mut q_at_s, &q_at_s_constant_part, &q_at_s_degree_one_part);
+            blst::blst_p1_add_or_double(
+                &mut q_at_s,
+                &q_at_s_constant_part,
+                &q_at_s_degree_one_part,
+            );
         }
 
         let z_as_scalar = blst_scalar_from_i8_as_abs(2);

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -25,6 +25,9 @@ impl From<&[i8]> for Polynomial {
 
 impl Polynomial {
     pub fn degree(&self) -> usize {
+        if self.coefficients.is_empty() {
+            return 0;
+        }
         self.coefficients.len() - 1
     }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -24,14 +24,14 @@ impl From<&[i8]> for Polynomial {
 }
 
 impl Polynomial {
-    pub fn order(&self) -> usize {
-        self.coefficients.len()
+    pub fn degree(&self) -> usize {
+        self.coefficients.len() - 1
     }
 
     pub fn commit(&self, setup_artifacts: &[SetupArtifact]) -> Result<G1Point, anyhow::Error> {
-        if self.order() > setup_artifacts.len() {
+        if self.degree() + 1 > setup_artifacts.len() {
             return Err(anyhow::anyhow!(
-                "Setup does not allow for commitment generation of the polynomial. The polynomial order is too high."
+                "Setup does not allow for commitment generation of the polynomial. The polynomial degree is too high."
             ));
         }
 
@@ -77,15 +77,15 @@ impl std::fmt::Display for Polynomial {
             return write!(f, "0");
         }
 
-        let higher_order_coefficient = self.coefficients[self.coefficients.len() - 1];
+        let higher_degree_coefficient = self.coefficients[self.coefficients.len() - 1];
         let mut displayed = format!(
             "{}{}",
-            if higher_order_coefficient < 0 {
+            if higher_degree_coefficient < 0 {
                 "-"
             } else {
                 ""
             },
-            display_non_zero_coefficient(higher_order_coefficient, self.coefficients.len() - 1)
+            display_non_zero_coefficient(higher_degree_coefficient, self.coefficients.len() - 1)
         );
 
         for i in (0..(self.coefficients.len() - 1)).rev() {
@@ -105,14 +105,14 @@ impl std::fmt::Display for Polynomial {
     }
 }
 
-fn display_non_zero_coefficient(c: i8, order: usize) -> String {
-    let order_string = match order {
+fn display_non_zero_coefficient(c: i8, degree: usize) -> String {
+    let degree_string = match degree {
         0 => "".to_owned(),
         1 => "x".to_owned(),
         other => format!("x^{other}"),
     };
-    if order > 0 && (c == 1 || c == -1) {
-        return order_string;
+    if degree > 0 && (c == 1 || c == -1) {
+        return degree_string;
     }
-    format!("{}{order_string}", c.abs())
+    format!("{}{degree_string}", c.abs())
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,0 +1,119 @@
+use serde::{Deserialize, Serialize};
+
+use crate::curves::G1Point;
+
+use super::trusted_setup::SetupArtifact;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Polynomial {
+    coefficients: Vec<i8>,
+}
+
+impl From<&[i8]> for Polynomial {
+    fn from(value: &[i8]) -> Self {
+        let mut coefficients = vec![0; value.len()];
+        coefficients.clone_from_slice(value);
+
+        while let Some(last_value) = coefficients.last()
+            && *last_value == 0
+        {
+            coefficients.pop();
+        }
+
+        Polynomial { coefficients }
+    }
+}
+
+impl Polynomial {
+    pub fn order(&self) -> usize {
+        self.coefficients.len()
+    }
+
+    pub fn commit(&self, setup_artifacts: &[SetupArtifact]) -> Result<G1Point, anyhow::Error> {
+        if self.order() > setup_artifacts.len() {
+            return Err(anyhow::anyhow!(
+                "Setup does not allow for commitment generation of the polynomial. The polynomial order is too high."
+            ));
+        }
+
+        let mut commitment = blst::blst_p1::default();
+        for (i, coefficient) in self.coefficients.iter().enumerate() {
+            let coefficient_as_scalar = blst_scalar_from_u8(coefficient.unsigned_abs());
+            let setup_point = &setup_artifacts[i].g1;
+
+            let mut contribution = blst::blst_p1::default();
+            unsafe {
+                blst::blst_p1_mult(
+                    &mut contribution,
+                    setup_point.as_raw_ptr(),
+                    coefficient_as_scalar.b.as_ptr(),
+                    coefficient_as_scalar.b.len() * 8,
+                );
+            };
+            if *coefficient < 0 {
+                unsafe {
+                    blst::blst_p1_cneg(&mut contribution, true);
+                }
+            }
+            unsafe {
+                blst::blst_p1_add_or_double(&mut commitment, &commitment, &contribution);
+            };
+        }
+
+        Ok(commitment.into())
+    }
+}
+
+pub fn blst_scalar_from_u8(a: u8) -> blst::blst_scalar {
+    let mut le_bytes = [0; 48];
+    le_bytes[0] = a;
+    let mut scalar = blst::blst_scalar::default();
+    unsafe { blst::blst_scalar_from_le_bytes(&mut scalar, le_bytes.as_ptr(), le_bytes.len()) };
+    scalar
+}
+
+impl std::fmt::Display for Polynomial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.coefficients.is_empty() {
+            return write!(f, "0");
+        }
+
+        let higher_order_coefficient = self.coefficients[self.coefficients.len() - 1];
+        let mut displayed = format!(
+            "{}{}",
+            if higher_order_coefficient < 0 {
+                "-"
+            } else {
+                ""
+            },
+            display_non_zero_coefficient(higher_order_coefficient, self.coefficients.len() - 1)
+        );
+
+        for i in (0..(self.coefficients.len() - 1)).rev() {
+            let c = self.coefficients[i];
+            if c == 0 {
+                continue;
+            }
+            displayed += format!(
+                " {} {}",
+                if c > 0 { "+" } else { "-" },
+                display_non_zero_coefficient(c, i)
+            )
+            .as_str();
+        }
+
+        write!(f, "{displayed}")
+    }
+}
+
+fn display_non_zero_coefficient(c: i8, order: usize) -> String {
+    let order_string = match order {
+        0 => "".to_owned(),
+        1 => "x".to_owned(),
+        other => format!("x^{other}"),
+    };
+    if order > 0 && (c == 1 || c == -1) {
+        return order_string;
+    }
+    format!("{}{order_string}", c.abs())
+}

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -37,7 +37,7 @@ impl Polynomial {
 
         let mut commitment = blst::blst_p1::default();
         for (i, coefficient) in self.coefficients.iter().enumerate() {
-            let coefficient_as_scalar = blst_scalar_from_u8(coefficient.unsigned_abs());
+            let coefficient_as_scalar = blst_scalar_from_i8_as_abs(*coefficient);
             let setup_point = &setup_artifacts[i].g1;
 
             let mut contribution = blst::blst_p1::default();
@@ -63,10 +63,10 @@ impl Polynomial {
     }
 }
 
-pub fn blst_scalar_from_u8(a: u8) -> blst::blst_scalar {
+pub fn blst_scalar_from_i8_as_abs(a: i8) -> blst::blst_scalar {
     let mut le_bytes = [0; 48];
-    le_bytes[0] = a;
-    let mut scalar = blst::blst_scalar::default();
+    le_bytes[0] = a.unsigned_abs();
+    let mut scalar: blst::blst_scalar = blst::blst_scalar::default();
     unsafe { blst::blst_scalar_from_le_bytes(&mut scalar, le_bytes.as_ptr(), le_bytes.len()) };
     scalar
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -11,8 +11,7 @@ pub struct Polynomial {
 
 impl From<&[i8]> for Polynomial {
     fn from(value: &[i8]) -> Self {
-        let mut coefficients = vec![0; value.len()];
-        coefficients.clone_from_slice(value);
+        let mut coefficients = value.to_vec();
 
         while let Some(last_value) = coefficients.last()
             && *last_value == 0

--- a/src/trusted_setup.rs
+++ b/src/trusted_setup.rs
@@ -1,9 +1,7 @@
 use num_bigint::BigUint;
-use serde::{
-    self, Deserialize, Serialize,
-    de::{self, MapAccess, SeqAccess, Visitor},
-    ser::SerializeStruct,
-};
+use serde::{self, Deserialize, Serialize};
+
+use super::curves;
 
 #[derive(Debug)]
 pub struct SetupArtifactsGenerator {
@@ -25,163 +23,10 @@ impl SetupArtifactsGenerator {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SetupArtifact {
-    pub g1: blst::blst_p1,
-    pub g2: blst::blst_p2,
-}
-
-impl Serialize for SetupArtifact {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("SetupArtifact", 2)?;
-
-        let mut compressed_p1 = [0; 48];
-        unsafe {
-            blst::blst_p1_compress(compressed_p1.as_mut_ptr(), &self.g1);
-        };
-        state.serialize_field("g1", &compressed_p1[..])?;
-
-        let mut compressed_p2 = [0; 96];
-        unsafe {
-            blst::blst_p2_compress(compressed_p2.as_mut_ptr(), &self.g2);
-        };
-        state.serialize_field("g2", &compressed_p2[..])?;
-
-        state.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for SetupArtifact {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
-        enum Field {
-            G1,
-            G2,
-        }
-
-        struct SetupArtifactVisitor;
-
-        fn vec_to_blst_p1(v: Vec<u8>) -> Result<blst::blst_p1, anyhow::Error> {
-            if v.len() != 48 {
-                return Err(anyhow::anyhow!(
-                    "Invalid length, expected 48, got {}",
-                    v.len()
-                ));
-            }
-
-            let mut compressed_p1 = [0u8; 48];
-            compressed_p1.copy_from_slice(&v);
-            let mut uncompressed_p1_affine = blst::blst_p1_affine::default();
-            unsafe {
-                match blst::blst_p1_uncompress(&mut uncompressed_p1_affine, compressed_p1.as_ptr())
-                {
-                    blst::BLST_ERROR::BLST_SUCCESS => Ok(()),
-                    other => Err(other),
-                }
-            }
-            .map_err(|err| anyhow::anyhow!("Got error while uncompressing: {err:?}"))?;
-
-            let mut uncompressed_p1 = blst::blst_p1::default();
-            unsafe {
-                blst::blst_p1_from_affine(&mut uncompressed_p1, &uncompressed_p1_affine);
-            };
-            Ok(uncompressed_p1)
-        }
-
-        fn vec_to_blst_p2(v: Vec<u8>) -> Result<blst::blst_p2, anyhow::Error> {
-            if v.len() != 96 {
-                return Err(anyhow::anyhow!(
-                    "Invalid length, expected 96, got {}",
-                    v.len()
-                ));
-            }
-
-            let mut compressed_p2 = [0u8; 96];
-            compressed_p2.copy_from_slice(&v);
-            let mut uncompressed_p2_affine = blst::blst_p2_affine::default();
-            unsafe {
-                match blst::blst_p2_uncompress(&mut uncompressed_p2_affine, compressed_p2.as_ptr())
-                {
-                    blst::BLST_ERROR::BLST_SUCCESS => Ok(()),
-                    other => Err(other),
-                }
-            }
-            .map_err(|err| anyhow::anyhow!("Got error while uncompressing: {err:?}"))?;
-
-            let mut uncompressed_p2 = blst::blst_p2::default();
-            unsafe {
-                blst::blst_p2_from_affine(&mut uncompressed_p2, &uncompressed_p2_affine);
-            };
-            Ok(uncompressed_p2)
-        }
-
-        impl<'de> Visitor<'de> for SetupArtifactVisitor {
-            type Value = SetupArtifact;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("struct SetupArtifact")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<SetupArtifact, V::Error>
-            where
-                V: SeqAccess<'de>,
-            {
-                let raw_g1: Vec<u8> = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let g1 = vec_to_blst_p1(raw_g1).map_err(de::Error::custom)?;
-
-                let raw_g2: Vec<u8> = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                let g2 = vec_to_blst_p2(raw_g2).map_err(de::Error::custom)?;
-
-                Ok(SetupArtifact { g1, g2 })
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<SetupArtifact, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut raw_g1: Option<Vec<u8>> = None;
-                let mut raw_g2: Option<Vec<u8>> = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::G1 => {
-                            if raw_g1.is_some() {
-                                return Err(de::Error::duplicate_field("g1"));
-                            }
-                            raw_g1 = Some(map.next_value()?);
-                        }
-                        Field::G2 => {
-                            if raw_g2.is_some() {
-                                return Err(de::Error::duplicate_field("g2"));
-                            }
-                            raw_g2 = Some(map.next_value()?);
-                        }
-                    }
-                }
-
-                let raw_g1 = raw_g1.ok_or_else(|| de::Error::missing_field("g1"))?;
-                let g1 = vec_to_blst_p1(raw_g1).map_err(de::Error::custom)?;
-
-                let raw_g2 = raw_g2.ok_or_else(|| de::Error::missing_field("g2"))?;
-                let g2 = vec_to_blst_p2(raw_g2).map_err(de::Error::custom)?;
-
-                Ok(SetupArtifact { g1, g2 })
-            }
-        }
-
-        const FIELDS: &[&str] = &["g1", "g2"];
-        deserializer.deserialize_struct("SetupArtifact", FIELDS, SetupArtifactVisitor)
-    }
+    pub g1: curves::G1Point,
+    pub g2: curves::G2Point,
 }
 
 impl Iterator for SetupArtifactsGenerator {
@@ -192,8 +37,8 @@ impl Iterator for SetupArtifactsGenerator {
             self.is_at_power_zero = false;
 
             return Some(SetupArtifact {
-                g1: unsafe { *blst::blst_p1_generator() },
-                g2: unsafe { *blst::blst_p2_generator() },
+                g1: unsafe { *blst::blst_p1_generator() }.into(),
+                g2: unsafe { *blst::blst_p2_generator() }.into(),
             });
         }
 
@@ -229,8 +74,8 @@ impl Iterator for SetupArtifactsGenerator {
         };
 
         Some(SetupArtifact {
-            g1: g1_artifact,
-            g2: g2_artifact,
+            g1: g1_artifact.into(),
+            g2: g2_artifact.into(),
         })
     }
 }


### PR DESCRIPTION
## Summary

The command `commit` is implemented, it takes the coefficients of a polynomial in arguments, retrieves the setup artifacts and finally compute the commitment.

The `Polynomial` struct has been added, it acts as a wrapper around the coefficients and manage the `commit` logic.

The `{G1, G2}Point` structures have been added in order to help with serialization and deserialization.
