### PR TITLE
Implement polynomial evaluation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,17 @@ Once `Q` has been derived from `P` and `(x_eval, y_eval)`, the computation of th
 
 The validation of the proof will be tackled in the next section.
 
+In terms of code, I added a few methods for the `Polynomial` struct, I will see if I gather them later on but I like it like this for now as it is very clear what is going on:
+```rust
+let y = commitment_artifact.polynomial.evaluate(x)?;
+let proof = commitment_artifact
+    .polynomial
+    .sub(Polynomial::try_from([y].as_slice())?)?
+    .divide_by_root(x)?
+    .commit(&setup_artifacts)?;
+```
+I used the fact that the `commit` is actually the evaluation at the secret `s` projected on `G1`, so commit for `Q` is actually the computation of the proof.
+
 ## Repository setup
 
 Environment variables can be set up using `.env` file at the root of the repository, see `.env.example` for a list of the supported environment variables.

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ const SETUP_ARTIFACTS_PATH: &str = "./artifacts/setup.json";
 const COMMITMENT_ARTIFACTS_PATH: &str = "./artifacts/commitment.json";
 const EVALUATION_ARTIFACTS_PATH: &str = "./artifacts/evaluation.json";
 
-const MAX_DEGREE: u8 = 9;
+const MAX_DEGREE: u32 = 9;
 
 impl Commands {
     fn run(&self) -> Result<(), CliError> {
@@ -121,7 +121,7 @@ impl Commands {
 
                 let setup_artifacts: Vec<_> =
                     trusted_setup::SetupArtifactsGenerator::new(s_be_bytes)
-                        .take(usize::from(MAX_DEGREE + 1))
+                        .take(usize::try_from(MAX_DEGREE + 1).map_err(anyhow::Error::from)?)
                         .collect();
 
                 let stringified_artifacts =
@@ -140,7 +140,7 @@ impl Commands {
 
                 let polynomial_displayed = polynomial.to_string();
 
-                if polynomial.degree() > usize::from(MAX_DEGREE) {
+                if polynomial.degree() > MAX_DEGREE {
                     return Err(
                         anyhow::anyhow!("Only polynomials up to degree 9 are supported").into(),
                     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ impl Commands {
                 let y = commitment_artifact.polynomial.evaluate(x)?;
                 let proof = commitment_artifact
                     .polynomial
-                    .sub(Polynomial::try_from([y].as_slice())?)?
+                    .sub(&Polynomial::try_from([y].as_slice())?)?
                     .divide_by_root(x)?
                     .commit(&setup_artifacts)?;
 
@@ -398,7 +398,7 @@ mod tests {
         let z = 1;
         let y = polynomial.evaluate(&z).unwrap();
         let proof = polynomial
-            .sub(Polynomial::try_from([y].as_slice()).unwrap())
+            .sub(&Polynomial::try_from([y].as_slice()).unwrap())
             .unwrap()
             .divide_by_root(&z)
             .unwrap()
@@ -442,7 +442,7 @@ mod tests {
         let z = 2;
         let y = polynomial.evaluate(&z).unwrap();
         let proof = polynomial
-            .sub(Polynomial::try_from([y].as_slice()).unwrap())
+            .sub(&Polynomial::try_from([y].as_slice()).unwrap())
             .unwrap()
             .divide_by_root(&z)
             .unwrap()
@@ -494,7 +494,7 @@ mod tests {
         let z = 2;
         let y = polynomial.evaluate(&z).unwrap();
         let proof = polynomial
-            .sub(Polynomial::try_from([y].as_slice()).unwrap())
+            .sub(&Polynomial::try_from([y].as_slice()).unwrap())
             .unwrap()
             .divide_by_root(&z)
             .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
     match &cli.command {
         Some(cmd) => {
             if let Err(e) = cmd.run() {
-                panic!("Command execution failed with error: {e}")
+                panic!("Command execution failed with error: {e}");
             }
         }
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ impl Commands {
 
                 let setup_artifacts: Vec<_> =
                     trusted_setup::SetupArtifactsGenerator::new(s_be_bytes)
-                        .take(usize::try_from(MAX_DEGREE + 1).map_err(anyhow::Error::from)?)
+                        .take((MAX_DEGREE + 1) as usize)
                         .collect();
 
                 let stringified_artifacts =

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ impl Commands {
                 let y = commitment_artifact.polynomial.evaluate(x)?;
                 let proof = commitment_artifact
                     .polynomial
-                    .sub(&Polynomial::try_from([y].as_slice())?)?
+                    .sub(&Polynomial::from_constant(y))?
                     .divide_by_root(x)?
                     .commit(&setup_artifacts)?;
 
@@ -398,7 +398,7 @@ mod tests {
         let z = 1;
         let y = polynomial.evaluate(&z).unwrap();
         let proof = polynomial
-            .sub(&Polynomial::try_from([y].as_slice()).unwrap())
+            .sub(&Polynomial::from_constant(y))
             .unwrap()
             .divide_by_root(&z)
             .unwrap()
@@ -442,7 +442,7 @@ mod tests {
         let z = 2;
         let y = polynomial.evaluate(&z).unwrap();
         let proof = polynomial
-            .sub(&Polynomial::try_from([y].as_slice()).unwrap())
+            .sub(&Polynomial::from_constant(y))
             .unwrap()
             .divide_by_root(&z)
             .unwrap()
@@ -494,7 +494,7 @@ mod tests {
         let z = 2;
         let y = polynomial.evaluate(&z).unwrap();
         let proof = polynomial
-            .sub(&Polynomial::try_from([y].as_slice()).unwrap())
+            .sub(&Polynomial::from_constant(y))
             .unwrap()
             .divide_by_root(&z)
             .unwrap()

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -65,7 +65,7 @@ impl Polynomial {
     /// Subtract a polynomial from the current one
     ///
     /// * `p` - Polynomial to subtract to the current one
-    pub fn sub(&self, p: Polynomial) -> Result<Polynomial, anyhow::Error> {
+    pub fn sub(&self, p: &Polynomial) -> Result<Polynomial, anyhow::Error> {
         let a_length = self.coefficients.len();
         let b_length = p.coefficients.len();
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -64,7 +64,7 @@ impl Polynomial {
 
     /// Subtract a polynomial from the current one
     ///
-    /// * `p` - Polynomial to subract to the current one
+    /// * `p` - Polynomial to subtract to the current one
     pub fn sub(&self, p: Polynomial) -> Result<Polynomial, anyhow::Error> {
         let a_length = self.coefficients.len();
         let b_length = p.coefficients.len();
@@ -95,12 +95,12 @@ impl Polynomial {
     ///
     /// * `root` - Root of the polynomial
     pub fn divide_by_root(&self, root: &i128) -> Result<Polynomial, anyhow::Error> {
-        let higher_order_cofficient = self.coefficients.last().ok_or(anyhow::anyhow!(
+        let higher_order_coefficient = self.coefficients.last().ok_or(anyhow::anyhow!(
             "Unable to divide a polynomial of degree zero"
         ))?;
-        let mut quotient_coefficients_reversed = vec![*higher_order_cofficient];
+        let mut quotient_coefficients_reversed = vec![*higher_order_coefficient];
         // We skip the higher degree as it is handled at initialisation, and we skip the degree zero as it is checked at the end
-        let mut last_coefficient_found = *higher_order_cofficient;
+        let mut last_coefficient_found = *higher_order_coefficient;
         for coefficient in self.coefficients.iter().skip(1).rev().skip(1) {
             let contribution_from_root =
                 root.checked_mul(last_coefficient_found)
@@ -111,7 +111,7 @@ impl Polynomial {
                 coefficient
                     .checked_add(contribution_from_root)
                     .ok_or(anyhow::anyhow!(
-                        "[divide_by_root] Overflow while {coefficient} * {contribution_from_root}"
+                        "[divide_by_root] Overflow while {coefficient} + {contribution_from_root}"
                     ))?;
 
             quotient_coefficients_reversed.push(last_coefficient_found);

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -108,7 +108,8 @@ impl Polynomial {
         let mut quotient_coefficients_reversed = vec![*higher_order_coefficient];
         // We skip the higher degree as it is handled at initialisation, and we skip the degree zero as it is checked at the end
         let mut last_coefficient_found = *higher_order_coefficient;
-        for coefficient in self.coefficients.iter().skip(1).rev().skip(1) {
+        for i in (1..self.coefficients.len() - 1).rev() {
+            let coefficient = self.coefficients[i];
             let contribution_from_root =
                 root.checked_mul(last_coefficient_found)
                     .ok_or(anyhow::anyhow!(

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -61,6 +61,9 @@ impl Polynomial {
         Ok(evaluation)
     }
 
+    /// Generate the G1Point representing the commit to the polynomial using setup artifacts.
+    ///
+    /// * `setup_artifacts` - List of setup artifacts for both elliptic curve groups. There must at least `degree + 1` artifacts.
     pub fn commit(&self, setup_artifacts: &[SetupArtifact]) -> Result<G1Point, anyhow::Error> {
         if self.degree() + 1 > setup_artifacts.len() {
             return Err(anyhow::anyhow!(

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -79,9 +79,9 @@ impl Polynomial {
                 ))?;
             }
         } else {
-            coefficients = p.coefficients.clone();
+            coefficients = p.coefficients.iter().map(|x| -x).collect();
             for (i, lhs) in self.coefficients.iter().enumerate() {
-                coefficients[i] = lhs.checked_sub(coefficients[i]).ok_or(anyhow::anyhow!(
+                coefficients[i] = lhs.checked_add(coefficients[i]).ok_or(anyhow::anyhow!(
                     "[sub] Overflow while {lhs} - {}",
                     coefficients[i]
                 ))?;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -175,9 +175,10 @@ impl Polynomial {
 }
 
 pub fn blst_scalar_from_i128_as_abs(a: i128) -> blst::blst_scalar {
-    let le_bytes = a.unsigned_abs().to_le_bytes();
+    let mut padded_bytes = [0u8; 48];
+    padded_bytes[..16].copy_from_slice(&a.unsigned_abs().to_le_bytes());
     let mut scalar: blst::blst_scalar = blst::blst_scalar::default();
-    unsafe { blst::blst_scalar_from_le_bytes(&mut scalar, le_bytes.as_ptr(), le_bytes.len()) };
+    unsafe { blst::blst_scalar_from_le_bytes(&mut scalar, padded_bytes.as_ptr(), padded_bytes.len()) };
     scalar
 }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -13,7 +13,7 @@ impl TryFrom<&[i128]> for Polynomial {
     type Error = anyhow::Error;
 
     fn try_from(value: &[i128]) -> Result<Self, Self::Error> {
-        if u32::try_from(value.len()).is_err() {
+        if value.len() > u32::MAX as usize {
             return Err(anyhow::anyhow!(
                 "Too many coefficients for polynomial, only 2**32 - 1 coefficients is supported. Got {}",
                 value.len()
@@ -160,8 +160,7 @@ impl Polynomial {
     ///
     /// * `setup_artifacts` - List of setup artifacts for both elliptic curve groups. There must at least `degree + 1` artifacts.
     pub fn commit(&self, setup_artifacts: &[SetupArtifact]) -> Result<G1Point, anyhow::Error> {
-        if usize::try_from(self.degree() + 1).map_err(anyhow::Error::from)? > setup_artifacts.len()
-        {
+        if (self.degree() + 1) as usize > setup_artifacts.len() {
             return Err(anyhow::anyhow!(
                 "Setup does not allow for commitment generation of the polynomial. The polynomial degree is too high."
             ));

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -79,7 +79,14 @@ impl Polynomial {
                 ))?;
             }
         } else {
-            coefficients = p.coefficients.iter().map(|x| -x).collect();
+            coefficients = p
+                .coefficients
+                .iter()
+                .map(|x| {
+                    x.checked_neg()
+                        .ok_or(anyhow::anyhow!("[sub] Overflow while negating {x}"))
+                })
+                .collect::<Result<Vec<_>, anyhow::Error>>()?;
             for (i, lhs) in self.coefficients.iter().enumerate() {
                 coefficients[i] = lhs.checked_add(coefficients[i]).ok_or(anyhow::anyhow!(
                     "[sub] Overflow while {lhs} - {}",
@@ -128,7 +135,7 @@ impl Polynomial {
             ))?
             .checked_neg()
             .ok_or(anyhow::anyhow!(
-                "[divide_by_root] Overflow while taking the negative of root"
+                "[divide_by_root] Overflow while taking the negative of rebuilt constant term"
             ))?;
         if rebuilt_constant_term != self.coefficients[0] {
             return Err(anyhow::anyhow!(

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -111,9 +111,23 @@ impl Polynomial {
     ///
     /// * `root` - Root of the polynomial
     pub fn divide_by_root(&self, root: &i128) -> Result<Polynomial, anyhow::Error> {
-        let higher_order_coefficient = self.coefficients.last().ok_or(anyhow::anyhow!(
-            "Unable to divide a polynomial of degree zero"
-        ))?;
+        let higher_order_coefficient = match self.coefficients.last() {
+            None => {
+                return Ok(Polynomial {
+                    coefficients: vec![],
+                });
+            }
+            Some(v) => v,
+        };
+        if self.coefficients.len() == 1 {
+            if *higher_order_coefficient == 0 {
+                return Ok(Polynomial {
+                    coefficients: vec![],
+                });
+            } else {
+                return Err(anyhow::anyhow!("Unable to divide a constant polynomial"));
+            }
+        }
         let mut quotient_coefficients_reversed = vec![*higher_order_coefficient];
         // We skip the higher degree as it is handled at initialisation, and we skip the degree zero as it is checked at the end
         let mut last_coefficient_found = *higher_order_coefficient;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -61,6 +61,9 @@ impl Polynomial {
         Ok(evaluation)
     }
 
+    /// Subtract a polynomial from the current one
+    ///
+    /// * `p` - Polynomial to subract to the current one
     pub fn sub(&self, p: Polynomial) -> Polynomial {
         let a_length = self.coefficients.len();
         let b_length = p.coefficients.len();
@@ -81,6 +84,9 @@ impl Polynomial {
         Polynomial::from(coefficients.as_ref())
     }
 
+    /// Divides the polynomial by the divider polynomial `x - root` and returns the quotient polynomial.
+    ///
+    /// * `root` - Root of the polynomial
     pub fn divide_by_root(&self, root: &i128) -> Result<Polynomial, anyhow::Error> {
         let higher_order_cofficient = self.coefficients.last().ok_or(anyhow::anyhow!(
             "Unable to divide a polynomial of degree zero"

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -120,7 +120,14 @@ impl Polynomial {
         quotient_coefficients_reversed.reverse();
 
         // We check that the constant term is correct: -1 * root * constant term of q = constant term of p
-        if -root * quotient_coefficients_reversed[0] != self.coefficients[0] {
+        let rebuilt_constant_term =
+            -root
+                .checked_mul(quotient_coefficients_reversed[0])
+                .ok_or(anyhow::anyhow!(
+                    "[divide_by_root] Overflow while {root} * {}",
+                    quotient_coefficients_reversed[0]
+                ))?;
+        if rebuilt_constant_term != self.coefficients[0] {
             return Err(anyhow::anyhow!(
                 "[divide_by_root] Fail to divide the polynomial by a root, constant terms do not add up"
             ));

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -35,7 +35,7 @@ impl TryFrom<&[i128]> for Polynomial {
 impl Polynomial {
     /// Return the degree of the polynomial.
     ///
-    /// Degree is derived as one plus the number of coefficients.
+    /// Degree is derived as one minus the number of coefficients.
     pub fn degree(&self) -> usize {
         if self.coefficients.is_empty() {
             return 0;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -120,13 +120,16 @@ impl Polynomial {
         quotient_coefficients_reversed.reverse();
 
         // We check that the constant term is correct: -1 * root * constant term of q = constant term of p
-        let rebuilt_constant_term =
-            -root
-                .checked_mul(quotient_coefficients_reversed[0])
-                .ok_or(anyhow::anyhow!(
-                    "[divide_by_root] Overflow while {root} * {}",
-                    quotient_coefficients_reversed[0]
-                ))?;
+        let rebuilt_constant_term = root
+            .checked_mul(quotient_coefficients_reversed[0])
+            .ok_or(anyhow::anyhow!(
+                "[divide_by_root] Overflow while {root} * {}",
+                quotient_coefficients_reversed[0]
+            ))?
+            .checked_neg()
+            .ok_or(anyhow::anyhow!(
+                "[divide_by_root] Overflow while taking the negative of root"
+            ))?;
         if rebuilt_constant_term != self.coefficients[0] {
             return Err(anyhow::anyhow!(
                 "[divide_by_root] Fail to divide the polynomial by a root, constant terms do not add up"

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -178,7 +178,9 @@ pub fn blst_scalar_from_i128_as_abs(a: i128) -> blst::blst_scalar {
     let mut padded_bytes = [0u8; 48];
     padded_bytes[..16].copy_from_slice(&a.unsigned_abs().to_le_bytes());
     let mut scalar: blst::blst_scalar = blst::blst_scalar::default();
-    unsafe { blst::blst_scalar_from_le_bytes(&mut scalar, padded_bytes.as_ptr(), padded_bytes.len()) };
+    unsafe {
+        blst::blst_scalar_from_le_bytes(&mut scalar, padded_bytes.as_ptr(), padded_bytes.len())
+    };
     scalar
 }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -43,6 +43,15 @@ impl Polynomial {
         (self.coefficients.len() - 1) as u32
     }
 
+    /// Creates a polynomial of order 0 from a constant
+    ///
+    /// * `a` - Constant
+    pub fn from_constant(a: i128) -> Polynomial {
+        Polynomial {
+            coefficients: vec![a],
+        }
+    }
+
     /// Evaluate the polynomial at an input point
     ///
     /// * `x` - Input point

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -64,7 +64,7 @@ impl Polynomial {
 
     /// Subtract a polynomial from the current one
     ///
-    /// * `p` - Polynomial to subtract to the current one
+    /// * `p` - Polynomial to subtract from the current one
     pub fn sub(&self, p: &Polynomial) -> Result<Polynomial, anyhow::Error> {
         let a_length = self.coefficients.len();
         let b_length = p.coefficients.len();


### PR DESCRIPTION
## Summary

The `evaluate` command is implemented, it allows to evaluate the committed polynomial at a given point and computes the associated Kate proof.

The need methods have been added directly on the `Polynomial` struct.

The coefficients of the polynomial are now `i128` instead of `i8` for simplicity.
