### PR TITLE
implement evaluation verification

### DIFF
--- a/src/curves.rs
+++ b/src/curves.rs
@@ -22,8 +22,77 @@ impl From<blst::blst_p1> for G1Point {
 }
 
 impl G1Point {
-    pub fn as_raw_ptr(&self) -> *const blst::blst_p1 {
+    /// Returns the wrapped point as raw pointer
+    fn as_raw_ptr(&self) -> *const blst::blst_p1 {
         &self.0
+    }
+
+    /// Project a scalar to the G1 curve using the generator
+    ///
+    /// * `a` - Scalar to project
+    pub fn from_i128(a: i128) -> Self {
+        let scalar = blst_scalar_from_i128_as_abs(a);
+        let mut out = blst::blst_p1::default();
+        unsafe {
+            blst::blst_p1_mult(
+                &mut out,
+                blst::blst_p1_generator(),
+                scalar.b.as_ptr(),
+                scalar.b.len() * 8,
+            );
+        };
+        if a < 0 {
+            unsafe {
+                blst::blst_p1_cneg(&mut out, true);
+            }
+        }
+        out.into()
+    }
+
+    /// Subtract two points and give the result as a new point
+    ///
+    /// * `b` - G1 point to subtract from self
+    pub fn sub(&self, b: &Self) -> Self {
+        let mut out = blst::blst_p1::default();
+        let mut neg_b = b.0;
+        unsafe {
+            blst::blst_p1_cneg(&mut neg_b, true);
+            blst::blst_p1_add_or_double(&mut out, self.as_raw_ptr(), &neg_b);
+        };
+        out.into()
+    }
+
+    /// Add two points and give the result as a new point
+    ///
+    /// * `b` - G1 point to add to self
+    pub fn add(&self, b: &Self) -> Self {
+        let mut out = blst::blst_p1::default();
+        unsafe {
+            blst::blst_p1_add_or_double(&mut out, self.as_raw_ptr(), b.as_raw_ptr());
+        };
+        out.into()
+    }
+
+    /// Multiply a point by a scalar and give the result as a new point
+    ///
+    /// * `a` - Integer that will multiply self
+    pub fn mult(&self, a: i128) -> Self {
+        let scalar = blst_scalar_from_i128_as_abs(a);
+        let mut out = blst::blst_p1::default();
+        unsafe {
+            blst::blst_p1_mult(
+                &mut out,
+                self.as_raw_ptr(),
+                scalar.b.as_ptr(),
+                scalar.b.len() * 8,
+            );
+        };
+        if a < 0 {
+            unsafe {
+                blst::blst_p1_cneg(&mut out, true);
+            }
+        }
+        out.into()
     }
 }
 
@@ -123,8 +192,44 @@ impl From<blst::blst_p2> for G2Point {
 }
 
 impl G2Point {
+    /// Returns the wrapped point as raw pointer
     pub fn as_raw_ptr(&self) -> *const blst::blst_p2 {
         &self.0
+    }
+
+    /// Project a scalar to the G2 curve using the generator
+    ///
+    /// * `a` - Scalar to project
+    pub fn from_i128(a: i128) -> Self {
+        let scalar = blst_scalar_from_i128_as_abs(a);
+        let mut out = blst::blst_p2::default();
+        unsafe {
+            blst::blst_p2_mult(
+                &mut out,
+                blst::blst_p2_generator(),
+                scalar.b.as_ptr(),
+                scalar.b.len() * 8,
+            );
+        };
+        if a < 0 {
+            unsafe {
+                blst::blst_p2_cneg(&mut out, true);
+            }
+        }
+        out.into()
+    }
+
+    /// Subtract two points and give the result as a new point
+    ///
+    /// * `b` - G2 point to subtract from self
+    pub fn sub(&self, b: &Self) -> Self {
+        let mut out = blst::blst_p2::default();
+        let mut neg_b = b.0;
+        unsafe {
+            blst::blst_p2_cneg(&mut neg_b, true);
+            blst::blst_p2_add_or_double(&mut out, self.as_raw_ptr(), &neg_b);
+        };
+        out.into()
     }
 }
 
@@ -219,4 +324,32 @@ impl<'de> Deserialize<'de> for G2Point {
 
         deserializer.deserialize_seq(G2PointVisitor)
     }
+}
+
+fn blst_scalar_from_i128_as_abs(a: i128) -> blst::blst_scalar {
+    let mut padded_bytes = [0u8; 48];
+    padded_bytes[..16].copy_from_slice(&a.unsigned_abs().to_le_bytes());
+    let mut scalar: blst::blst_scalar = blst::blst_scalar::default();
+    unsafe {
+        blst::blst_scalar_from_le_bytes(&mut scalar, padded_bytes.as_ptr(), padded_bytes.len())
+    };
+    scalar
+}
+
+pub fn bilinear_map(p1: &G1Point, p2: &G2Point) -> blst::blst_fp12 {
+    let mut p1_affine = blst::blst_p1_affine::default();
+    unsafe {
+        blst::blst_p1_to_affine(&mut p1_affine, p1.as_raw_ptr());
+    };
+    let mut p2_affine = blst::blst_p2_affine::default();
+    unsafe {
+        blst::blst_p2_to_affine(&mut p2_affine, p2.as_raw_ptr());
+    };
+
+    let mut res = blst::blst_fp12::default();
+    unsafe {
+        blst::blst_miller_loop(&mut res, &p2_affine, &p1_affine);
+        blst::blst_final_exp(&mut res, &res);
+    };
+    res
 }

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -193,7 +193,7 @@ impl From<blst::blst_p2> for G2Point {
 
 impl G2Point {
     /// Returns the wrapped point as raw pointer
-    pub fn as_raw_ptr(&self) -> *const blst::blst_p2 {
+    fn as_raw_ptr(&self) -> *const blst::blst_p2 {
         &self.0
     }
 


### PR DESCRIPTION
## Summary

Implement the command in order to verify the previous evaluation with its proof.

The `blst` crate is now isolated in `curves.rs`.
