### PR TITLE
update readme, move proof generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,15 @@ if lhs != rhs {
 ```
 
 
+### Factorisation and testing
+
+I moved a few things around in the implementation, in particular:
+- the `Evaluation` struct has been introduced in order to abstract the result of a polynomial evaluation,
+- the proof generation and verification for a polynomial evaluation have been moved to `Evaluation::generate_proof` and `Evaluation::verify_proof`.
+
+The tests are now run using random values. From this, I discovered a lot of overflows errors for polynomial with high degrees or high coefficients. I need to dig a bit on how to solve this properly.
+
+
 ## Repository setup
 
 Environment variables can be set up using `.env` file at the root of the repository, see `.env.example` for a list of the supported environment variables.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ mod tests {
         let commitment = polynomial.commit(setup_artifacts).unwrap();
 
         let evaluation = polynomial.evaluate(&input_point).unwrap();
-        let proof = polynomial
-            .generate_evaluation_proof(&evaluation, setup_artifacts)
+        let proof = evaluation
+            .generate_proof(polynomial, setup_artifacts)
             .unwrap();
         assert!(
             evaluation

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,9 +216,8 @@ impl Commands {
                     serde_json::from_reader(reader).map_err(anyhow::Error::from)?;
 
                 let evaluation = commitment_artifact.polynomial.evaluate(x)?;
-                let proof = commitment_artifact
-                    .polynomial
-                    .generate_evaluation_proof(&evaluation, &setup_artifacts)?;
+                let proof =
+                    evaluation.generate_proof(&commitment_artifact.polynomial, &setup_artifacts)?;
 
                 let evaluation_artifact =
                     serde_json::to_string(&EvaluationArtifact { evaluation, proof })

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -40,6 +40,21 @@ pub struct Evaluation {
 }
 
 impl Evaluation {
+    /// Generates a Kate proof for a given evaluation
+    ///
+    /// * `polynomial` - The polynomial associated with the evaluation
+    /// * `setup_artifacts` - List of setup artifacts for both elliptic curve groups. There must at least `degree` artifacts.
+    pub fn generate_proof(
+        &self,
+        polynomial: &Polynomial,
+        setup_artifacts: &[SetupArtifact],
+    ) -> Result<G1Point, anyhow::Error> {
+        polynomial
+            .sub(&Polynomial::from_constant(self.result))?
+            .divide_by_root(&self.point)?
+            .commit(setup_artifacts)
+    }
+
     /// Verify the Kate proof given a proof, a commitment and the setup artifacts
     ///
     /// * `proof` - Evaluation proof
@@ -104,20 +119,6 @@ impl Polynomial {
             point: *x,
             result: evaluation,
         })
-    }
-
-    /// Generates a Kate proof for a given evaluation
-    ///
-    /// * `evaluation` - The evaluation for which the proof is generated
-    /// * `setup_artifacts` - List of setup artifacts for both elliptic curve groups. There must at least `degree` artifacts.
-    pub fn generate_evaluation_proof(
-        &self,
-        evaluation: &Evaluation,
-        setup_artifacts: &[SetupArtifact],
-    ) -> Result<G1Point, anyhow::Error> {
-        self.sub(&Polynomial::from_constant(evaluation.result))?
-            .divide_by_root(&evaluation.point)?
-            .commit(setup_artifacts)
     }
 
     /// Subtract a polynomial from the current one


### PR DESCRIPTION
## Summary

The `readme` is updated with latest developments.

The proof generation is moved to `Evaluation::generate_proof`
