### PR TITLE
add scalar module, use it for trusted setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +241,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "fake",
+ "hex",
  "log",
  "num-bigint",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ blst = { version = "0.3.15", features = [] }
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
-num-bigint = "0.4.6"
 rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
@@ -20,3 +19,5 @@ thiserror = "2.0.12"
 
 [dev-dependencies]
 fake = "4.3.0"
+num-bigint = "0.4.6"
+hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -379,6 +379,9 @@ I moved a few things around in the implementation, in particular:
 
 The tests are now run using random values. From this, I discovered a lot of overflow errors for polynomial with high degrees or high coefficients. I need to dig a bit on how to solve this properly.
 
+### Scalars
+
+I originally thought that the secret, the power of the secret and the polynomial coefficients should be in the prime field `F_q`. I understood that I was wrong and that these quantities are actually living in `F_r` the prime field built associated to the subgroups we want to target. Instead of the 48 bytes I was previously using, I am left with 32, and all the operations are made in the `F_r` group. I still need to find a proper explanation somewhere in the documentation for this.
 
 ## Repository setup
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod curves;
 pub mod polynomial;
+pub mod scalar;
 pub mod trusted_setup;
 
 #[cfg(test)]
@@ -44,7 +45,7 @@ mod tests {
     }
 
     fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
-        let mut s_bytes = [0; 48]; // Field elements are encoded in big endian form with 48 bytes
+        let mut s_bytes = [0; 32]; // Secret is a 256-bit scalar
         rand::rng().fill_bytes(&mut s_bytes);
         SetupArtifactsGenerator::new(s_bytes)
             .take((degree + 1) as usize)

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ impl Commands {
                 }
                 let mut file = fs::File::create(SETUP_ARTIFACTS_PATH)?;
 
-                let mut s_be_bytes = [0; 48];
+                let mut s_be_bytes = [0; 32];
                 rand::rng().fill_bytes(&mut s_be_bytes);
 
                 let setup_artifacts: Vec<_> =

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -114,6 +114,7 @@ mod tests {
             // Always safe to do as R is bigger than i128 maximum value
             let expected_big_uint =
                 BigUint::from_bytes_be(&r_be_bytes) - BigUint::from_bytes_le(&unsigned_a_le_bytes);
+            // It will always fit in 32 bytes as R fits in 32 bytes and is in any case larger than the unsigned part of the input
             expected_le_bytes[..].copy_from_slice(expected_big_uint.to_bytes_le().as_slice());
         }
         assert_eq!(recovered_le_bytes, expected_le_bytes);

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -111,6 +111,7 @@ mod tests {
         } else {
             let unsigned_a_le_bytes = a.unsigned_abs().to_le_bytes();
             let r_be_bytes = hex::decode(R_AS_HEX).unwrap();
+            // Always safe to do as R is bigger than i128 maximum value
             let expected_big_uint =
                 BigUint::from_bytes_be(&r_be_bytes) - BigUint::from_bytes_le(&unsigned_a_le_bytes);
             expected_le_bytes[..].copy_from_slice(expected_big_uint.to_bytes_le().as_slice());

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,0 +1,141 @@
+#[derive(Debug)]
+pub struct Scalar {
+    as_fr: blst::blst_fr,
+}
+
+const R_AS_HEX: &str = "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001";
+
+fn le_bytes_to_hex(a: &[u8]) -> String {
+    let mut out = "".to_string();
+    for b in a.iter().rev() {
+        out += format!("{b:02x?}").as_str();
+    }
+    out
+}
+fn be_bytes_to_hex(a: &[u8]) -> String {
+    let mut out = "".to_string();
+    for b in a.iter() {
+        out += format!("{b:02x?}").as_str();
+    }
+    out
+}
+
+impl Scalar {
+    pub fn from_le_bytes(b: [u8; 32]) -> Self {
+        let hexa = le_bytes_to_hex(&b);
+        let mut fr = blst::blst_fr::default();
+        unsafe {
+            blst::blst_fr_from_hexascii(&mut fr, hexa.as_ptr());
+        }
+        Self { as_fr: fr }
+    }
+
+    pub fn from_be_bytes(b: [u8; 32]) -> Self {
+        let mut fr = blst::blst_fr::default();
+        let hexa = be_bytes_to_hex(&b);
+        unsafe {
+            blst::blst_fr_from_hexascii(&mut fr, hexa.as_ptr());
+        }
+        Self { as_fr: fr }
+    }
+
+    pub fn from_i128(a: i128) -> Self {
+        let mut unsigned_le_bytes = [0u8; 32];
+        unsigned_le_bytes[..16].copy_from_slice(&a.unsigned_abs().to_le_bytes());
+        let unsigned_hexa = le_bytes_to_hex(&unsigned_le_bytes);
+        let mut fr = blst::blst_fr::default();
+        unsafe {
+            blst::blst_fr_from_hexascii(&mut fr, unsigned_hexa.as_ptr());
+        }
+        if a > 0 {
+            return Self { as_fr: fr };
+        }
+
+        let mut r = blst::blst_fr::default();
+        unsafe {
+            blst::blst_fr_from_hexascii(&mut r, R_AS_HEX.as_ptr());
+            blst::blst_fr_sub(&mut fr, &r, &fr);
+        };
+
+        Self { as_fr: fr }
+    }
+
+    pub fn to_le_bytes(&self) -> [u8; 32] {
+        let mut scalar = blst::blst_scalar::default();
+        unsafe {
+            blst::blst_scalar_from_fr(&mut scalar, &self.as_fr);
+        }
+        let mut le_bytes = [0u8; 32];
+        unsafe {
+            blst::blst_lendian_from_scalar(le_bytes.as_mut_ptr(), &scalar);
+        }
+        le_bytes
+    }
+
+    pub fn to_be_bytes(&self) -> [u8; 32] {
+        let mut scalar = blst::blst_scalar::default();
+        unsafe {
+            blst::blst_scalar_from_fr(&mut scalar, &self.as_fr);
+        }
+        let mut be_bytes = [0u8; 32];
+        unsafe {
+            blst::blst_bendian_from_scalar(be_bytes.as_mut_ptr(), &scalar);
+        }
+        be_bytes
+    }
+
+    pub fn mul(&self, a: &Self) -> Self {
+        let mut out = blst::blst_fr::default();
+        unsafe {
+            blst::blst_fr_mul(&mut out, &self.as_fr, &a.as_fr);
+        };
+        Self { as_fr: out }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fake::{Fake, Faker};
+    use num_bigint::BigUint;
+
+    use super::*;
+
+    #[test]
+    fn test_i128_to_scalar_using_le() {
+        let a: i128 = Faker.fake();
+        let scalar = Scalar::from_i128(a);
+        let recovered_le_bytes = scalar.to_le_bytes();
+        let mut expected_le_bytes = [0u8; 32];
+        if a > 0 {
+            expected_le_bytes[..16].copy_from_slice(&a.to_le_bytes());
+        } else {
+            let unsigned_a_le_bytes = a.unsigned_abs().to_le_bytes();
+            let r_be_bytes = hex::decode(R_AS_HEX).unwrap();
+            let expected_big_uint =
+                BigUint::from_bytes_be(&r_be_bytes) - BigUint::from_bytes_le(&unsigned_a_le_bytes);
+            expected_le_bytes[..].copy_from_slice(expected_big_uint.to_bytes_le().as_slice());
+        }
+        assert_eq!(recovered_le_bytes, expected_le_bytes);
+    }
+
+    #[test]
+    fn test_u128_to_scalar_using_le() {
+        let a: u128 = Faker.fake();
+        let mut le_bytes = [0u8; 32];
+        le_bytes[..16].copy_from_slice(&a.to_le_bytes());
+        let scalar = Scalar::from_le_bytes(le_bytes);
+        let recovered_le_bytes = scalar.to_le_bytes();
+        assert_eq!(recovered_le_bytes, le_bytes);
+    }
+
+    #[test]
+    fn test_u128_to_scalar_using_be() {
+        let a: u128 = Faker.fake();
+        let mut be_bytes = [0u8; 32];
+        be_bytes[..16].copy_from_slice(&a.to_le_bytes());
+        be_bytes.reverse();
+        let scalar = Scalar::from_be_bytes(be_bytes);
+        let recovered_be_bytes = scalar.to_be_bytes();
+        assert_eq!(recovered_be_bytes, be_bytes);
+    }
+}

--- a/src/trusted_setup.rs
+++ b/src/trusted_setup.rs
@@ -1,9 +1,9 @@
 use serde::{self, Deserialize, Serialize};
 
 use super::{
+    curves,
     curves::{G1Point, G2Point},
     scalar::Scalar,
-    curves
 };
 
 #[derive(Debug)]

--- a/src/trusted_setup.rs
+++ b/src/trusted_setup.rs
@@ -1,24 +1,29 @@
-use num_bigint::BigUint;
 use serde::{self, Deserialize, Serialize};
 
-use super::curves;
+use super::{
+    curves::{G1Point, G2Point},
+    scalar::Scalar,
+    curves
+};
 
 #[derive(Debug)]
 pub struct SetupArtifactsGenerator {
-    secret: BigUint,
+    secret: Scalar,
     is_at_power_zero: bool,
-    current_s_powered: BigUint,
+    current_s_powered: Scalar,
 }
 
 impl SetupArtifactsGenerator {
     /// Creates a new generator for trusted setup artifacts
     ///
     /// * `secret` - Secret used to generate artifacts, in big endian bytes
-    pub fn new(secret: [u8; 48]) -> Self {
+    pub fn new(secret: [u8; 32]) -> Self {
+        let mut one_le_bytes = [0; 32];
+        one_le_bytes[0] = 1;
         Self {
-            secret: BigUint::from_bytes_be(&secret),
+            secret: Scalar::from_be_bytes(secret),
             is_at_power_zero: true,
-            current_s_powered: BigUint::from(1u8),
+            current_s_powered: Scalar::from_le_bytes(one_le_bytes),
         }
     }
 }
@@ -37,29 +42,22 @@ impl Iterator for SetupArtifactsGenerator {
             self.is_at_power_zero = false;
 
             return Some(SetupArtifact {
-                g1: unsafe { *blst::blst_p1_generator() }.into(),
-                g2: unsafe { *blst::blst_p2_generator() }.into(),
+                g1: G1Point::from_i128(1),
+                g2: G2Point::from_i128(1),
             });
         }
 
-        self.current_s_powered *= &self.secret;
+        self.current_s_powered = self.current_s_powered.mul(&self.secret);
 
-        let s_powered_be_bytes = self.current_s_powered.to_bytes_be();
-        let mut s_powered_as_scalar = blst::blst_scalar::default();
-        unsafe {
-            blst::blst_scalar_from_be_bytes(
-                &mut s_powered_as_scalar,
-                s_powered_be_bytes.as_ptr(),
-                s_powered_be_bytes.len(),
-            );
-        };
+        let s_powered_le_bytes = self.current_s_powered.to_le_bytes();
+
         let mut g1_artifact = blst::blst_p1::default();
         unsafe {
             blst::blst_p1_mult(
                 &mut g1_artifact,
                 blst::blst_p1_generator(),
-                s_powered_as_scalar.b.as_ptr(),
-                s_powered_as_scalar.b.len() * 8,
+                s_powered_le_bytes.as_ptr(),
+                s_powered_le_bytes.len() * 8,
             );
         };
 
@@ -68,8 +66,8 @@ impl Iterator for SetupArtifactsGenerator {
             blst::blst_p2_mult(
                 &mut g2_artifact,
                 blst::blst_p2_generator(),
-                s_powered_as_scalar.b.as_ptr(),
-                s_powered_as_scalar.b.len() * 8,
+                s_powered_le_bytes.as_ptr(),
+                s_powered_le_bytes.len() * 8,
             );
         };
 


### PR DESCRIPTION
## Summary

The `scalar` module is added as an abstraction over the field element of the `fr` sub group. It is used for the trusted setup module.

A later PR will use it for polynomial coefficients.

