### PR TITLE
Set polynomial coefficients as scalar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .env
 /artifacts
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +246,7 @@ name = "kzg_poly_commit_exploration"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atoi",
  "blst",
  "clap",
  "dotenvy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,7 +237,6 @@ name = "kzg_poly_commit_exploration"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atoi",
  "blst",
  "clap",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.98"
+atoi = "2.0.0"
 blst = { version = "0.3.15", features = [] }
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
+num-bigint = "0.4.6"
 rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
@@ -19,5 +21,4 @@ thiserror = "2.0.12"
 
 [dev-dependencies]
 fake = "4.3.0"
-num-bigint = "0.4.6"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.98"
-atoi = "2.0.0"
 blst = { version = "0.3.15", features = [] }
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ blst = { version = "0.3.15", features = [] }
 clap = { version = "4.5.41", features = ["derive"] }
 dotenvy = "0.15.7"
 log = "0.4.27"
-num-bigint = "0.4.6"
 rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
@@ -21,3 +20,4 @@ thiserror = "2.0.12"
 [dev-dependencies]
 fake = "4.3.0"
 hex = "0.4.3"
+num-bigint = "0.4.6"

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -10,13 +10,6 @@ use crate::scalar::Scalar;
 #[derive(Debug)]
 pub struct G1Point(blst::blst_p1);
 
-impl Deref for G1Point {
-    type Target = blst::blst_p1;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl From<blst::blst_p1> for G1Point {
     fn from(value: blst::blst_p1) -> Self {
         G1Point(value)

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -5,6 +5,8 @@ use serde::{
     de::{self, Visitor},
 };
 
+use crate::scalar::Scalar;
+
 #[derive(Debug)]
 pub struct G1Point(blst::blst_p1);
 
@@ -49,6 +51,22 @@ impl G1Point {
         out.into()
     }
 
+    /// Project a scalar to the G1 curve using the generator
+    ///
+    /// * `a` - Scalar to project
+    pub fn from_scalar(a: Scalar) -> Self {
+        let mut out = blst::blst_p1::default();
+        unsafe {
+            blst::blst_p1_mult(
+                &mut out,
+                blst::blst_p1_generator(),
+                a.to_le_bytes().as_ptr(),
+                256,
+            );
+        };
+        out.into()
+    }
+
     /// Subtract two points and give the result as a new point
     ///
     /// * `b` - G1 point to subtract from self
@@ -75,23 +93,12 @@ impl G1Point {
 
     /// Multiply a point by a scalar and give the result as a new point
     ///
-    /// * `a` - Integer that will multiply self
-    pub fn mult(&self, a: i128) -> Self {
-        let scalar = blst_scalar_from_i128_as_abs(a);
+    /// * `a` - Scalar that will multiply self
+    pub fn mult(&self, a: &Scalar) -> Self {
         let mut out = blst::blst_p1::default();
         unsafe {
-            blst::blst_p1_mult(
-                &mut out,
-                self.as_raw_ptr(),
-                scalar.b.as_ptr(),
-                scalar.b.len() * 8,
-            );
+            blst::blst_p1_mult(&mut out, self.as_raw_ptr(), a.to_le_bytes().as_ptr(), 256);
         };
-        if a < 0 {
-            unsafe {
-                blst::blst_p1_cneg(&mut out, true);
-            }
-        }
         out.into()
     }
 }
@@ -216,6 +223,22 @@ impl G2Point {
                 blst::blst_p2_cneg(&mut out, true);
             }
         }
+        out.into()
+    }
+
+    /// Project a scalar to the G2 curve using the generator
+    ///
+    /// * `a` - Scalar to project
+    pub fn from_scalar(a: Scalar) -> Self {
+        let mut out = blst::blst_p2::default();
+        unsafe {
+            blst::blst_p2_mult(
+                &mut out,
+                blst::blst_p2_generator(),
+                a.to_le_bytes().as_ptr(),
+                256,
+            );
+        };
         out.into()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ mod tests {
             .collect()
     }
 
-    // TODO: Testing indicates some limitations on the possible values for the coefficients and the input points. There is a need to fix this and increase the coverage of these tests.
     #[test]
     fn test_kate_proof_for_polynomial_degree_one_over_multiple_input() {
         let setup_artifacts = &generate_setup_artifacts(1);
@@ -80,6 +79,7 @@ mod tests {
         let input_point = Scalar::from_i128(Faker.fake::<i128>());
 
         for _ in 0..10 {
+            // TODO: Testing indicates some limitations on the possible values for the degree. There is a need to fix this and increase the coverage of these tests.
             let degree: u8 = Faker.fake();
             if degree == 0 {
                 continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,19 +5,22 @@ pub mod trusted_setup;
 
 #[cfg(test)]
 mod tests {
-    use crate::trusted_setup::SetupArtifactsGenerator;
-    use crate::{polynomial::Polynomial, trusted_setup::SetupArtifact};
+    use crate::{
+        polynomial::Polynomial,
+        scalar::Scalar,
+        trusted_setup::{SetupArtifact, SetupArtifactsGenerator},
+    };
     use fake::{Fake, Faker};
     use rand::RngCore;
 
     fn run_kate_proof_test(
         polynomial: &Polynomial,
-        input_point: i128,
+        input_point: Scalar,
         setup_artifacts: &[SetupArtifact],
     ) {
         let commitment = polynomial.commit(setup_artifacts).unwrap();
 
-        let evaluation = polynomial.evaluate(&input_point).unwrap();
+        let evaluation = polynomial.evaluate(input_point.clone()).unwrap();
         let proof = evaluation
             .generate_proof(polynomial, setup_artifacts)
             .unwrap();
@@ -34,7 +37,7 @@ mod tests {
         for _ in 0..(degree + 1) {
             coefficients.push(Faker.fake());
         }
-        Polynomial::try_from(coefficients.as_slice()).unwrap()
+        Polynomial::try_from(coefficients).unwrap()
     }
 
     fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
@@ -53,7 +56,7 @@ mod tests {
             let polynomial = generate_polynomial(1);
 
             for _ in 0..10 {
-                let input_point: i128 = Faker.fake();
+                let input_point = Scalar::from_i128(Faker.fake::<i128>());
                 run_kate_proof_test(&polynomial, input_point, setup_artifacts);
             }
         }
@@ -66,7 +69,7 @@ mod tests {
             let polynomial = generate_polynomial(2);
 
             for _ in 0..10 {
-                let input_point: i128 = Faker.fake();
+                let input_point = Scalar::from_i128(Faker.fake::<i128>());
                 run_kate_proof_test(&polynomial, input_point, setup_artifacts);
             }
         }
@@ -74,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_kate_proof_over_multiple_degree_with_fixed_input() {
-        let input_point: i128 = Faker.fake();
+        let input_point = Scalar::from_i128(Faker.fake::<i128>());
 
         for _ in 0..10 {
             let degree: u8 = Faker.fake();
@@ -85,7 +88,7 @@ mod tests {
 
             run_kate_proof_test(
                 &polynomial,
-                input_point,
+                input_point.clone(),
                 &generate_setup_artifacts(degree as u32),
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,18 +30,11 @@ mod tests {
     }
 
     fn generate_polynomial(degree: u32) -> Polynomial {
-        let mut coefficients: Vec<i32> = vec![];
+        let mut coefficients: Vec<i128> = vec![];
         for _ in 0..(degree + 1) {
             coefficients.push(Faker.fake());
         }
-        Polynomial::try_from(
-            coefficients
-                .into_iter()
-                .map(i128::from)
-                .collect::<Vec<i128>>()
-                .as_slice(),
-        )
-        .unwrap()
+        Polynomial::try_from(coefficients.as_slice()).unwrap()
     }
 
     fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
@@ -60,8 +53,8 @@ mod tests {
             let polynomial = generate_polynomial(1);
 
             for _ in 0..10 {
-                let input_point: i32 = Faker.fake();
-                run_kate_proof_test(&polynomial, input_point.into(), setup_artifacts);
+                let input_point: i128 = Faker.fake();
+                run_kate_proof_test(&polynomial, input_point, setup_artifacts);
             }
         }
     }
@@ -73,14 +66,16 @@ mod tests {
             let polynomial = generate_polynomial(2);
 
             for _ in 0..10 {
-                let input_point: i32 = Faker.fake();
-                run_kate_proof_test(&polynomial, input_point.into(), setup_artifacts);
+                let input_point: i128 = Faker.fake();
+                run_kate_proof_test(&polynomial, input_point, setup_artifacts);
             }
         }
     }
 
     #[test]
     fn test_kate_proof_over_multiple_degree_with_fixed_input() {
+        let input_point: i128 = Faker.fake();
+
         for _ in 0..10 {
             let degree: u8 = Faker.fake();
             if degree == 0 {
@@ -88,11 +83,9 @@ mod tests {
             }
             let polynomial = generate_polynomial(degree as u32);
 
-            let input_point: u8 = 1;
-
             run_kate_proof_test(
                 &polynomial,
-                input_point.into(),
+                input_point,
                 &generate_setup_artifacts(degree as u32),
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,10 @@ fn main() {
         _ => log::Level::Trace,
     };
 
-    if let Err(err) = dotenvy::dotenv() {
-        if !err.not_found() {
-            panic!("Error while loading .env file: {err}")
-        }
+    if let Err(err) = dotenvy::dotenv()
+        && !err.not_found()
+    {
+        panic!("Error while loading .env file: {err}")
     }
 
     let log_level = match std::env::var("LOG_LEVEL").ok() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,6 @@ impl Commands {
                 let proof =
                     evaluation.generate_proof(&commitment_artifact.polynomial, &setup_artifacts)?;
 
-                // REMIND ME
                 let evaluation_artifact = serde_json::to_string(&EvaluationArtifact {
                     evaluation: evaluation.clone(),
                     proof,

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,9 +219,12 @@ impl Commands {
                 let proof =
                     evaluation.generate_proof(&commitment_artifact.polynomial, &setup_artifacts)?;
 
-                let evaluation_artifact =
-                    serde_json::to_string(&EvaluationArtifact { evaluation, proof })
-                        .map_err(anyhow::Error::from)?;
+                // REMIND ME
+                let evaluation_artifact = serde_json::to_string(&EvaluationArtifact {
+                    evaluation: evaluation.clone(),
+                    proof,
+                })
+                .map_err(anyhow::Error::from)?;
 
                 if fs::exists(EVALUATION_ARTIFACTS_PATH)? {
                     fs::remove_file(EVALUATION_ARTIFACTS_PATH)?;

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -102,10 +102,10 @@ impl Polynomial {
         (self.coefficients.len() - 1) as u32
     }
 
-    /// Creates a polynomial of order 0 from a constant
+    /// Creates a polynomial of order 0 from a scalar
     ///
-    /// * `a` - Constant
-    pub fn from_constant(a: Scalar) -> Self {
+    /// * `a` - Scalar
+    fn from_constant(a: Scalar) -> Self {
         Self::from(a)
     }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -60,19 +60,16 @@ impl TryFrom<Vec<Scalar>> for Polynomial {
             ));
         }
 
+        let mut last_non_zero_index = 0;
         let mut coefficients: Vec<Scalar> = vec![];
-        let mut is_empty = true;
-        for v in value.iter().rev() {
-            if is_empty {
-                if v.is_zero() {
-                    continue;
-                } else {
-                    is_empty = false;
-                }
+        for (i, v) in value.into_iter().enumerate() {
+            if !v.is_zero() {
+                last_non_zero_index = i;
             }
-            coefficients.push(v.clone());
+            coefficients.push(v);
         }
-        coefficients.reverse();
+
+        coefficients.truncate(last_non_zero_index + 1);
 
         Ok(Polynomial { coefficients })
     }
@@ -294,5 +291,32 @@ impl Evaluation {
         );
 
         Ok(lhs == rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_polynomial_with_tailing_zeros() {
+        assert_eq!(
+            Polynomial::try_from(vec![0, 0, 0, 0, 0]).unwrap().degree(),
+            0
+        );
+        assert_eq!(
+            Polynomial::try_from(vec![1, 0, 0, 0, 0]).unwrap().degree(),
+            0
+        );
+        assert_eq!(
+            Polynomial::try_from(vec![1, 0, 1, 0, 0]).unwrap().degree(),
+            2
+        );
+        assert_eq!(
+            Polynomial::try_from(vec![1, 0, 1, 0, 0, 5])
+                .unwrap()
+                .degree(),
+            5
+        );
     }
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -127,19 +127,19 @@ impl Polynomial {
 
     /// Subtract a polynomial from the current one
     ///
-    /// * `p` - Polynomial to subtract from the current one
-    pub fn sub(&self, p: &Self) -> Result<Self, anyhow::Error> {
+    /// * `other` - Polynomial to subtract from the current one
+    pub fn sub(&self, other: &Self) -> Result<Self, anyhow::Error> {
         let a_length = self.coefficients.len();
-        let b_length = p.coefficients.len();
+        let b_length = other.coefficients.len();
 
         let mut coefficients: Vec<Scalar>;
         if a_length > b_length {
             coefficients = self.coefficients.clone();
-            for (i, rhs) in p.coefficients.iter().enumerate() {
+            for (i, rhs) in other.coefficients.iter().enumerate() {
                 coefficients[i] = coefficients[i].sub(rhs);
             }
         } else {
-            coefficients = p.coefficients.iter().map(|x| x.neg()).collect();
+            coefficients = other.coefficients.iter().map(|x| x.neg()).collect();
             for (i, lhs) in self.coefficients.iter().enumerate() {
                 coefficients[i] = lhs.add(&coefficients[i]);
             }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -220,17 +220,51 @@ impl<'de> Deserialize<'de> for Scalar {
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let displayed = display_le_bytes(&self.to_le_bytes())
+        let displayed = le_bytes_to_base_10_string(&self.to_le_bytes())
             .map_err(|e| std::fmt::Error::custom(e.to_string()))?;
 
         write!(f, "{displayed}")
     }
 }
-fn display_le_bytes(le_bytes: &[u8]) -> Result<String, anyhow::Error> {
+fn le_bytes_to_base_10_string(le_bytes: &[u8]) -> Result<String, anyhow::Error> {
     let mut digits: Vec<u8> = vec![];
 
     let mut quotient = le_bytes.to_vec();
 
+    /*
+     * Example with 257 decomposed as [1, 1]:
+     *  * First loop iteration, using [1, 1]:
+     *      ~ First byte:
+     *          - to_be_divided = 0 | 1 = 1
+     *          - byte updated to 1 / 10 = 0
+     *          - next_digit = 1 % 10 = 1
+     *      ~ Second byte:
+     *          - to_be_divided = (1 << 8) | 1 = 257
+     *          - byte updated to 257 / 10 = 25
+     *          - next_digit = 257 % 10 = 7
+     *      => found digit is 7
+     *  * Second loop iteration, using [25, 0]:
+     *      ~ First byte:
+     *          - to_be_divided = 0 | 0 = 0
+     *          - byte updated to 0 / 10 = 0
+     *          - next_digit = 0 % 10 = 0
+     *      ~ Second byte:
+     *           - to_be_divided = 0 | 25 = 25
+     *           - byte updated to 25 / 10 = 2
+     *           - next_digit = 25 % 10 = 5
+     *      => found digit is 5
+     *  * Third loop iteration, using [2, 0]:
+     *      ~ First byte:
+     *          - to_be_divided = 0 | 0 = 0
+     *          - byte updated to 0 / 10 = 0
+     *          - next_digit = 0 % 10 = 0
+     *      ~ Second byte:
+     *           - to_be_divided = 0 | 2 = 2
+     *           - byte updated to 2 / 10 = 0
+     *           - next_digit = 2 % 10 = 2
+     *      => found digit is 2
+     *  => After reversion, digits are [2, 5, 7]
+     */
     while quotient.iter().any(|&byte| byte != 0) {
         let mut next_digit: u16 = 0;
         for byte in quotient.iter_mut().rev() {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -232,37 +232,41 @@ fn le_bytes_to_base_10_string(le_bytes: &[u8]) -> Result<String, anyhow::Error> 
 
     /*
      * Example with 257 decomposed as [1, 1]:
-     *  * First loop iteration, using [1, 1]:
-     *      ~ First byte:
-     *          - to_be_divided = 0 | 1 = 1
-     *          - byte updated to 1 / 10 = 0
-     *          - next_digit = 1 % 10 = 1
-     *      ~ Second byte:
-     *          - to_be_divided = (1 << 8) | 1 = 257
-     *          - byte updated to 257 / 10 = 25
-     *          - next_digit = 257 % 10 = 7
-     *      => found digit is 7
-     *  * Second loop iteration, using [25, 0]:
-     *      ~ First byte:
-     *          - to_be_divided = 0 | 0 = 0
-     *          - byte updated to 0 / 10 = 0
-     *          - next_digit = 0 % 10 = 0
-     *      ~ Second byte:
-     *           - to_be_divided = 0 | 25 = 25
-     *           - byte updated to 25 / 10 = 2
-     *           - next_digit = 25 % 10 = 5
-     *      => found digit is 5
-     *  * Third loop iteration, using [2, 0]:
-     *      ~ First byte:
-     *          - to_be_divided = 0 | 0 = 0
-     *          - byte updated to 0 / 10 = 0
-     *          - next_digit = 0 % 10 = 0
-     *      ~ Second byte:
-     *           - to_be_divided = 0 | 2 = 2
-     *           - byte updated to 2 / 10 = 0
-     *           - next_digit = 2 % 10 = 2
-     *      => found digit is 2
-     *  => After reversion, digits are [2, 5, 7]
+     *
+     * First loop iteration, using [1, 1]:
+     *   - First byte:
+     *       to_be_divided = 0 | 1 = 1
+     *       byte updated to 1 / 10 = 0
+     *       next_digit = 1 % 10 = 1
+     *   - Second byte:
+     *       to_be_divided = (1 << 8) | 1 = 257
+     *       byte updated to 257 / 10 = 25
+     *       next_digit = 257 % 10 = 7
+     *   => found digit is 7
+     *
+     * Second loop iteration, using [25, 0]:
+     *   - First byte:
+     *       to_be_divided = 0 | 0 = 0
+     *       byte updated to 0 / 10 = 0
+     *       next_digit = 0 % 10 = 0
+     *   - Second byte:
+     *       to_be_divided = 0 | 25 = 25
+     *       byte updated to 25 / 10 = 2
+     *       next_digit = 25 % 10 = 5
+     *   => found digit is 5
+     *
+     * Third loop iteration, using [2, 0]:
+     *   - First byte:
+     *       to_be_divided = 0 | 0 = 0
+     *       byte updated to 0 / 10 = 0
+     *       next_digit = 0 % 10 = 0
+     *   - Second byte:
+     *       to_be_divided = 0 | 2 = 2
+     *       byte updated to 2 / 10 = 0
+     *       next_digit = 2 % 10 = 2
+     *   => found digit is 2
+     *
+     * After reversion, digits are [2, 5, 7]
      */
     while quotient.iter().any(|&byte| byte != 0) {
         let mut next_digit: u16 = 0;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -7,9 +7,7 @@ use serde::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Scalar {
-    as_fr: blst::blst_fr,
-}
+pub struct Scalar(blst::blst_fr);
 
 const R_AS_HEX: &str = "73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001";
 
@@ -38,7 +36,7 @@ impl From<i128> for Scalar {
             blst::blst_fr_from_hexascii(&mut fr, unsigned_hexa.as_ptr());
         }
         if value > 0 {
-            return Self { as_fr: fr };
+            return Self(fr);
         }
 
         let mut r = blst::blst_fr::default();
@@ -47,7 +45,7 @@ impl From<i128> for Scalar {
             blst::blst_fr_sub(&mut fr, &r, &fr);
         };
 
-        Self { as_fr: fr }
+        Self(fr)
     }
 }
 
@@ -61,7 +59,7 @@ impl Scalar {
         unsafe {
             blst::blst_fr_from_hexascii(&mut fr, hexa.as_ptr());
         }
-        Self { as_fr: fr }
+        Self(fr)
     }
 
     /// Creates a scalar from big endian bytes
@@ -73,7 +71,7 @@ impl Scalar {
         unsafe {
             blst::blst_fr_from_hexascii(&mut fr, hexa.as_ptr());
         }
-        Self { as_fr: fr }
+        Self(fr)
     }
 
     /// Creates a scalar from a i128
@@ -87,7 +85,7 @@ impl Scalar {
     pub fn to_le_bytes(&self) -> [u8; 32] {
         let mut scalar = blst::blst_scalar::default();
         unsafe {
-            blst::blst_scalar_from_fr(&mut scalar, &self.as_fr);
+            blst::blst_scalar_from_fr(&mut scalar, &self.0);
         }
         let mut le_bytes = [0u8; 32];
         unsafe {
@@ -100,7 +98,7 @@ impl Scalar {
     pub fn to_be_bytes(&self) -> [u8; 32] {
         let mut scalar = blst::blst_scalar::default();
         unsafe {
-            blst::blst_scalar_from_fr(&mut scalar, &self.as_fr);
+            blst::blst_scalar_from_fr(&mut scalar, &self.0);
         }
         let mut be_bytes = [0u8; 32];
         unsafe {
@@ -115,22 +113,22 @@ impl Scalar {
     pub fn mul(&self, other: &Self) -> Self {
         let mut out = blst::blst_fr::default();
         unsafe {
-            blst::blst_fr_mul(&mut out, &self.as_fr, &other.as_fr);
+            blst::blst_fr_mul(&mut out, &self.0, &other.0);
         };
-        Self { as_fr: out }
+        Self(out)
     }
 
     /// Returns a new scalar obtained by the multiplication of self by itself a given number of times
     ///
     /// - `n` - Number of times to multiply self by itself
     pub fn pow(&self, n: usize) -> Self {
-        let mut out = Scalar::from_i128(1).as_fr;
+        let mut out = Scalar::from_i128(1).0;
         for _ in 0..n {
             unsafe {
-                blst::blst_fr_mul(&mut out, &out, &self.as_fr);
+                blst::blst_fr_mul(&mut out, &out, &self.0);
             }
         }
-        Scalar { as_fr: out }
+        Scalar(out)
     }
 
     /// Returns a new scalar obtained by the addition of self and another scalar
@@ -139,9 +137,9 @@ impl Scalar {
     pub fn add(&self, other: &Self) -> Self {
         let mut out = blst::blst_fr::default();
         unsafe {
-            blst::blst_fr_add(&mut out, &self.as_fr, &other.as_fr);
+            blst::blst_fr_add(&mut out, &self.0, &other.0);
         }
-        Scalar { as_fr: out }
+        Scalar(out)
     }
 
     /// Returns a new scalar obtained by the subtraction of self by another scalar
@@ -150,23 +148,23 @@ impl Scalar {
     pub fn sub(&self, other: &Self) -> Self {
         let mut out = blst::blst_fr::default();
         unsafe {
-            blst::blst_fr_sub(&mut out, &self.as_fr, &other.as_fr);
+            blst::blst_fr_sub(&mut out, &self.0, &other.0);
         }
-        Scalar { as_fr: out }
+        Scalar(out)
     }
 
     /// Returns a new scalar obtained by the negation of self
     pub fn neg(&self) -> Self {
         let mut out = blst::blst_fr::default();
         unsafe {
-            blst::blst_fr_cneg(&mut out, &self.as_fr, true);
+            blst::blst_fr_cneg(&mut out, &self.0, true);
         }
-        Scalar { as_fr: out }
+        Scalar(out)
     }
 
-    /// Returns if self is the representation of zero
+    /// Returns true if self is the representation of zero, false otherwise
     pub fn is_zero(&self) -> bool {
-        self.as_fr == blst::blst_fr::default()
+        self.0 == blst::blst_fr::default()
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,7 +1,6 @@
 use serde::{
     Deserialize, Serialize,
     de::{self, Visitor},
-    ser::Error,
 };
 use std::fmt::Display;
 
@@ -220,10 +219,10 @@ impl<'de> Deserialize<'de> for Scalar {
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let displayed = le_bytes_to_base_10_string(&self.to_le_bytes())
-            .map_err(|e| std::fmt::Error::custom(e.to_string()))?;
-
-        write!(f, "{displayed}")
+        match le_bytes_to_base_10_string(&self.to_le_bytes()) {
+            Err(e) => write!(f, "Error while displaying {self:?}. Error is {e}"),
+            Ok(s) => write!(f, "{s}")
+        }
     }
 }
 fn le_bytes_to_base_10_string(le_bytes: &[u8]) -> Result<String, anyhow::Error> {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -221,7 +221,7 @@ impl Display for Scalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match le_bytes_to_base_10_string(&self.to_le_bytes()) {
             Err(e) => write!(f, "Error while displaying {self:?}. Error is {e}"),
-            Ok(s) => write!(f, "{s}")
+            Ok(s) => write!(f, "{s}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Polynomial coefficients are updated as `Scalar` instead of `i128`. Tests are updated with larger test values.

Documentation and practice alignement have been made on multiple part of the codebase, in particular:
- missing documentation for the functions has been added,
- constructor methods have been moved to `From` or `TryFrom` trait implementations, they are repeated if needed directly in the implementations of the associated structure.
