### PR TITLE
Add fixed input in benchmark, add benchmark configuration, split evaluation and proof benchmarks

### DIFF
--- a/benches/evaluation_verification.rs
+++ b/benches/evaluation_verification.rs
@@ -1,26 +1,27 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use fake::{Fake, Faker};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
     scalar::Scalar,
     trusted_setup::{SetupArtifact, SetupArtifactsGenerator},
 };
-use rand::RngCore;
 
 fn generate_polynomial(degree: u32) -> Polynomial {
-    let mut coefficients: Vec<i128> = vec![];
-    for _ in 0..(degree + 1) {
-        coefficients.push(Faker.fake());
-    }
+    let coefficients: Vec<Scalar> = (0..(degree + 1))
+        .map(|i| Scalar::from(5).pow(i as usize).add(&Scalar::from(10)))
+        .collect();
     Polynomial::try_from(coefficients).unwrap()
 }
 
 fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
     let mut s_bytes = [0; 32]; // Secret is a 256-bit scalar
-    rand::rng().fill_bytes(&mut s_bytes);
+    s_bytes.copy_from_slice(&(0..32).collect::<Vec<u8>>());
     SetupArtifactsGenerator::new(s_bytes)
         .take((degree + 1) as usize)
         .collect()
+}
+
+fn generate_input_point(degree: u32) -> Scalar {
+    Scalar::from(5).pow(degree as usize).add(&Scalar::from(20))
 }
 
 fn bench_evaluation_verification(c: &mut Criterion) {
@@ -30,34 +31,27 @@ fn bench_evaluation_verification(c: &mut Criterion) {
     let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
+        // Fix input point
+        let input_point = generate_input_point(*degree);
+        // Setup: Generate all required artifacts for each iteration
+        let polynomial = generate_polynomial(*degree);
+        let setup_artifacts = generate_setup_artifacts(*degree);
+
+        // Generate commitment, evaluation, and proof
+        let commitment = polynomial.commit(&setup_artifacts).unwrap();
+        let evaluation = polynomial.evaluate(input_point.clone()).unwrap();
+        let proof = evaluation
+            .generate_proof(&polynomial, &setup_artifacts)
+            .unwrap();
+
         group.bench_with_input(
             BenchmarkId::new("verify_proof", degree),
-            degree,
-            |b, &degree| {
-                b.iter_batched(
-                    || {
-                        // Setup: Generate all required artifacts for each iteration
-                        let polynomial = generate_polynomial(degree);
-                        let setup_artifacts = generate_setup_artifacts(degree);
-                        let input_point = Scalar::from_i128(Faker.fake::<i128>());
-
-                        // Generate commitment, evaluation, and proof
-                        let commitment = polynomial.commit(&setup_artifacts).unwrap();
-                        let evaluation = polynomial.evaluate(input_point).unwrap();
-                        let proof = evaluation
-                            .generate_proof(&polynomial, &setup_artifacts)
-                            .unwrap();
-
-                        (evaluation, proof, commitment, setup_artifacts)
-                    },
-                    |(evaluation, proof, commitment, setup_artifacts)| {
-                        // Benchmark: Verify proof
-                        let _is_valid = evaluation
-                            .verify_proof(&proof, &commitment, &setup_artifacts)
-                            .unwrap();
-                    },
-                    criterion::BatchSize::SmallInput,
-                );
+            &(&evaluation, &proof, &commitment, &setup_artifacts),
+            |b, (eval, proof, commit, artifacts)| {
+                b.iter(|| {
+                    // Benchmark: Verify proof
+                    let _is_valid = eval.verify_proof(proof, commit, artifacts).unwrap();
+                });
             },
         );
     }

--- a/benches/evaluation_verification.rs
+++ b/benches/evaluation_verification.rs
@@ -27,7 +27,7 @@ fn bench_evaluation_verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("evaluation_verification");
 
     // Test with different polynomial degrees
-    let degrees = [1, 5, 10, 25, 50];
+    let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
         group.bench_with_input(

--- a/benches/evaluation_verification.rs
+++ b/benches/evaluation_verification.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
@@ -26,6 +28,7 @@ fn generate_input_point(degree: u32) -> Scalar {
 
 fn bench_evaluation_verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("evaluation_verification");
+    group.measurement_time(Duration::from_secs_f32(25.0)).sample_size(50);
 
     // Test with different polynomial degrees
     let degrees = [1, 100, 500, 1_000, 2_500];

--- a/benches/polynomial_commitment.rs
+++ b/benches/polynomial_commitment.rs
@@ -26,7 +26,7 @@ fn bench_polynomial_commitment(c: &mut Criterion) {
     let mut group = c.benchmark_group("polynomial_commitment");
 
     // Test with different polynomial degrees as specified
-    let degrees = [1, 10, 25, 50, 100];
+    let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
         group.bench_with_input(BenchmarkId::new("commit", degree), degree, |b, &degree| {

--- a/benches/polynomial_commitment.rs
+++ b/benches/polynomial_commitment.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
@@ -22,6 +24,7 @@ fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
 
 fn bench_polynomial_commitment(c: &mut Criterion) {
     let mut group = c.benchmark_group("polynomial_commitment");
+    group.measurement_time(Duration::from_secs_f32(10.0)).sample_size(75);
 
     // Test with different polynomial degrees as specified
     let degrees = [1, 100, 500, 1_000, 2_500];

--- a/benches/polynomial_commitment.rs
+++ b/benches/polynomial_commitment.rs
@@ -1,22 +1,20 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use fake::{Fake, Faker};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
+    scalar::Scalar,
     trusted_setup::{SetupArtifact, SetupArtifactsGenerator},
 };
-use rand::RngCore;
 
 fn generate_polynomial(degree: u32) -> Polynomial {
-    let mut coefficients: Vec<i128> = vec![];
-    for _ in 0..(degree + 1) {
-        coefficients.push(Faker.fake());
-    }
+    let coefficients: Vec<Scalar> = (0..(degree + 1))
+        .map(|i| Scalar::from(5).pow(i as usize).add(&Scalar::from(10)))
+        .collect();
     Polynomial::try_from(coefficients).unwrap()
 }
 
 fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
     let mut s_bytes = [0; 32]; // Secret is a 256-bit scalar
-    rand::rng().fill_bytes(&mut s_bytes);
+    s_bytes.copy_from_slice(&(0..32).collect::<Vec<u8>>());
     SetupArtifactsGenerator::new(s_bytes)
         .take((degree + 1) as usize)
         .collect()
@@ -29,21 +27,19 @@ fn bench_polynomial_commitment(c: &mut Criterion) {
     let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
-        group.bench_with_input(BenchmarkId::new("commit", degree), degree, |b, &degree| {
-            b.iter_batched(
-                || {
-                    // Setup: Generate polynomial and setup artifacts for each iteration
-                    let polynomial = generate_polynomial(degree);
-                    let setup_artifacts = generate_setup_artifacts(degree);
-                    (polynomial, setup_artifacts)
-                },
-                |(polynomial, setup_artifacts)| {
+        let polynomial = generate_polynomial(*degree);
+        let setup_artifacts = generate_setup_artifacts(*degree);
+
+        group.bench_with_input(
+            BenchmarkId::new("commit", degree),
+            &(&polynomial, &setup_artifacts),
+            |b, (p, artifacts)| {
+                b.iter(|| {
                     // Benchmark: Commit to polynomial
-                    let _commitment = polynomial.commit(&setup_artifacts).unwrap();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
+                    let _commitment = p.commit(artifacts).unwrap();
+                });
+            },
+        );
     }
 
     group.finish();

--- a/benches/polynomial_evaluation.rs
+++ b/benches/polynomial_evaluation.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
@@ -26,6 +28,7 @@ fn generate_input_point(degree: u32) -> Scalar {
 
 fn bench_polynomial_evaluation_and_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("polynomial_evaluation_and_proof");
+    group.measurement_time(Duration::from_secs_f32(25.0)).sample_size(50);
 
     // Test with different polynomial degrees
     let degrees = [1, 100, 500, 1_000, 2_500];

--- a/benches/polynomial_evaluation.rs
+++ b/benches/polynomial_evaluation.rs
@@ -27,7 +27,7 @@ fn bench_polynomial_evaluation_and_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("polynomial_evaluation_and_proof");
 
     // Test with different polynomial degrees
-    let degrees = [1, 5, 10, 25, 50];
+    let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
         // Benchmark polynomial evaluation

--- a/benches/polynomial_evaluation.rs
+++ b/benches/polynomial_evaluation.rs
@@ -4,7 +4,6 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
     scalar::Scalar,
-    trusted_setup::{SetupArtifact, SetupArtifactsGenerator},
 };
 
 fn generate_polynomial(degree: u32) -> Polynomial {
@@ -12,14 +11,6 @@ fn generate_polynomial(degree: u32) -> Polynomial {
         .map(|i| Scalar::from(5).pow(i as usize).add(&Scalar::from(10)))
         .collect();
     Polynomial::try_from(coefficients).unwrap()
-}
-
-fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
-    let mut s_bytes = [0; 32]; // Secret is a 256-bit scalar
-    s_bytes.copy_from_slice(&(0..32).collect::<Vec<u8>>());
-    SetupArtifactsGenerator::new(s_bytes)
-        .take((degree + 1) as usize)
-        .collect()
 }
 
 fn generate_input_point(degree: u32) -> Scalar {
@@ -46,21 +37,6 @@ fn bench_polynomial_evaluation_and_proof(c: &mut Criterion) {
                 b.iter(|| {
                     // Benchmark: Evaluate polynomial
                     let _evaluation = p.evaluate(input.clone()).unwrap();
-                });
-            },
-        );
-
-        // Setup: Generate polynomial, setup artifacts, evaluation point, and evaluation for each iteration
-        let setup_artifacts = generate_setup_artifacts(*degree);
-        let evaluation = polynomial.evaluate(input_point.clone()).unwrap();
-        // Benchmark proof generation
-        group.bench_with_input(
-            BenchmarkId::new("proof_generation", degree),
-            &(&polynomial, &evaluation, &setup_artifacts),
-            |b, (p, eval, artifacts)| {
-                b.iter(|| {
-                    // Benchmark: Generate proof only
-                    let _proof = eval.generate_proof(p, artifacts).unwrap();
                 });
             },
         );

--- a/benches/polynomial_evaluation.rs
+++ b/benches/polynomial_evaluation.rs
@@ -1,26 +1,27 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use fake::{Fake, Faker};
 use kzg_poly_commit_exploration::{
     polynomial::Polynomial,
     scalar::Scalar,
     trusted_setup::{SetupArtifact, SetupArtifactsGenerator},
 };
-use rand::RngCore;
 
 fn generate_polynomial(degree: u32) -> Polynomial {
-    let mut coefficients: Vec<i128> = vec![];
-    for _ in 0..(degree + 1) {
-        coefficients.push(Faker.fake());
-    }
+    let coefficients: Vec<Scalar> = (0..(degree + 1))
+        .map(|i| Scalar::from(5).pow(i as usize).add(&Scalar::from(10)))
+        .collect();
     Polynomial::try_from(coefficients).unwrap()
 }
 
 fn generate_setup_artifacts(degree: u32) -> Vec<SetupArtifact> {
     let mut s_bytes = [0; 32]; // Secret is a 256-bit scalar
-    rand::rng().fill_bytes(&mut s_bytes);
+    s_bytes.copy_from_slice(&(0..32).collect::<Vec<u8>>());
     SetupArtifactsGenerator::new(s_bytes)
         .take((degree + 1) as usize)
         .collect()
+}
+
+fn generate_input_point(degree: u32) -> Scalar {
+    Scalar::from(5).pow(degree as usize).add(&Scalar::from(20))
 }
 
 fn bench_polynomial_evaluation_and_proof(c: &mut Criterion) {
@@ -30,49 +31,34 @@ fn bench_polynomial_evaluation_and_proof(c: &mut Criterion) {
     let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
+        // Fix input point
+        let input_point = generate_input_point(*degree);
+
+        let polynomial = generate_polynomial(*degree);
         // Benchmark polynomial evaluation
         group.bench_with_input(
             BenchmarkId::new("evaluate", degree),
-            degree,
-            |b, &degree| {
-                b.iter_batched(
-                    || {
-                        // Setup: Generate polynomial and evaluation point for each iteration
-                        let polynomial = generate_polynomial(degree);
-                        let input_point = Scalar::from_i128(Faker.fake::<i128>());
-                        (polynomial, input_point)
-                    },
-                    |(polynomial, input_point)| {
-                        // Benchmark: Evaluate polynomial
-                        let _evaluation = polynomial.evaluate(input_point).unwrap();
-                    },
-                    criterion::BatchSize::SmallInput,
-                );
+            &(&polynomial, input_point.clone()),
+            |b, (p, input)| {
+                b.iter(|| {
+                    // Benchmark: Evaluate polynomial
+                    let _evaluation = p.evaluate(input.clone()).unwrap();
+                });
             },
         );
 
+        // Setup: Generate polynomial, setup artifacts, evaluation point, and evaluation for each iteration
+        let setup_artifacts = generate_setup_artifacts(*degree);
+        let evaluation = polynomial.evaluate(input_point.clone()).unwrap();
         // Benchmark proof generation
         group.bench_with_input(
             BenchmarkId::new("proof_generation", degree),
-            degree,
-            |b, &degree| {
-                b.iter_batched(
-                    || {
-                        // Setup: Generate polynomial, setup artifacts, evaluation point, and evaluation for each iteration
-                        let polynomial = generate_polynomial(degree);
-                        let setup_artifacts = generate_setup_artifacts(degree);
-                        let input_point = Scalar::from_i128(Faker.fake::<i128>());
-                        let evaluation = polynomial.evaluate(input_point).unwrap();
-                        (polynomial, setup_artifacts, evaluation)
-                    },
-                    |(polynomial, setup_artifacts, evaluation)| {
-                        // Benchmark: Generate proof only
-                        let _proof = evaluation
-                            .generate_proof(&polynomial, &setup_artifacts)
-                            .unwrap();
-                    },
-                    criterion::BatchSize::SmallInput,
-                );
+            &(&polynomial, &evaluation, &setup_artifacts),
+            |b, (p, eval, artifacts)| {
+                b.iter(|| {
+                    // Benchmark: Generate proof only
+                    let _proof = eval.generate_proof(p, artifacts).unwrap();
+                });
             },
         );
     }

--- a/benches/trusted_setup.rs
+++ b/benches/trusted_setup.rs
@@ -1,8 +1,11 @@
+use std::time::Duration;
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kzg_poly_commit_exploration::trusted_setup::SetupArtifactsGenerator;
 
 fn bench_trusted_setup_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("trusted_setup_generation");
+    group.measurement_time(Duration::from_secs_f32(25.0)).sample_size(75);
 
     // Test with different polynomial degrees as specified
     let degrees = [1, 100, 500, 1_000, 2_500];

--- a/benches/trusted_setup.rs
+++ b/benches/trusted_setup.rs
@@ -1,6 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kzg_poly_commit_exploration::trusted_setup::SetupArtifactsGenerator;
-use rand::RngCore;
 
 fn bench_trusted_setup_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("trusted_setup_generation");
@@ -8,26 +7,20 @@ fn bench_trusted_setup_generation(c: &mut Criterion) {
     // Test with different polynomial degrees as specified
     let degrees = [1, 100, 500, 1_000, 2_500];
 
+    let mut s_bytes = [0; 32]; // Secret is a 256-bit scalar
+    s_bytes.copy_from_slice(&(0..32).collect::<Vec<u8>>());
+
     for degree in degrees.iter() {
         group.bench_with_input(
             BenchmarkId::new("setup_generation", degree),
             degree,
             |b, &degree| {
-                b.iter_batched(
-                    || {
-                        // Setup: Generate random secret for each iteration
-                        let mut s_bytes = [0; 32];
-                        rand::rng().fill_bytes(&mut s_bytes);
-                        s_bytes
-                    },
-                    |s_bytes| {
-                        // Benchmark: Generate setup artifacts
-                        let _setup_artifacts: Vec<_> = SetupArtifactsGenerator::new(s_bytes)
-                            .take((degree + 1) as usize)
-                            .collect();
-                    },
-                    criterion::BatchSize::SmallInput,
-                );
+                b.iter(|| {
+                    // Benchmark: Generate setup artifacts
+                    let _setup_artifacts: Vec<_> = SetupArtifactsGenerator::new(s_bytes)
+                        .take((degree + 1) as usize)
+                        .collect();
+                });
             },
         );
     }

--- a/benches/trusted_setup.rs
+++ b/benches/trusted_setup.rs
@@ -6,7 +6,7 @@ fn bench_trusted_setup_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("trusted_setup_generation");
 
     // Test with different polynomial degrees as specified
-    let degrees = [2, 20, 2_000];
+    let degrees = [2, 500, 5_000];
 
     for degree in degrees.iter() {
         group.bench_with_input(

--- a/benches/trusted_setup.rs
+++ b/benches/trusted_setup.rs
@@ -6,7 +6,7 @@ fn bench_trusted_setup_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("trusted_setup_generation");
 
     // Test with different polynomial degrees as specified
-    let degrees = [2, 500, 5_000];
+    let degrees = [1, 100, 500, 1_000, 2_500];
 
     for degree in degrees.iter() {
         group.bench_with_input(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,7 @@ mod tests {
         let input_point = Scalar::from_i128(Faker.fake::<i128>());
 
         for _ in 0..10 {
-            // TODO: Testing indicates some limitations on the possible values for the degree. There is a need to fix this and increase the coverage of these tests.
-            let degree: u8 = Faker.fake();
+            let degree: u16 = (0..2_000).fake();
             if degree == 0 {
                 continue;
             }


### PR DESCRIPTION
This pull request refactors and standardizes the benchmarking code for polynomial commitment, evaluation, proof generation, verification, and trusted setup in the `benches` directory. It replaces randomized inputs with deterministic ones, unifies the set of polynomial degrees tested, and improves benchmarking configuration for consistency and reproducibility. The changes also remove unnecessary dependencies and simplify the code structure.

**Benchmark configuration and input standardization:**

* All benchmark files now use a consistent set of polynomial degrees: `[1, 100, 500, 1_000, 2_500]`, replacing previously smaller or random sets. This ensures uniform performance testing across all benchmarks. [[1]](diffhunk://#diff-0ab594c0325c3dff69fcf669d4434fdfc89aa59f812d6ae725e85e8916894749R1-L46) [[2]](diffhunk://#diff-f36f0527c47b86bcaf33bf9e4101e8323a146fc31973f9f54855f174690f0f8fR1-R57) [[3]](diffhunk://#diff-caebd835984e8bfd468406b44a4516dae63f4cd0fba25e34537032d02a2033a4R1-R40) [[4]](diffhunk://#diff-d18135f34714079f23c094b04ce36e9b8480fbc62817e14b83f3eb3b7437c920R1-R26)
* Randomized coefficients and secrets have been replaced with deterministic values, improving reproducibility. Coefficients are now generated as powers of 5 plus 10, and secrets use a fixed byte pattern. [[1]](diffhunk://#diff-0ab594c0325c3dff69fcf669d4434fdfc89aa59f812d6ae725e85e8916894749R1-L46) [[2]](diffhunk://#diff-f36f0527c47b86bcaf33bf9e4101e8323a146fc31973f9f54855f174690f0f8fR1-R57) [[3]](diffhunk://#diff-d18135f34714079f23c094b04ce36e9b8480fbc62817e14b83f3eb3b7437c920R1-R26) [[4]](diffhunk://#diff-a16db9296de46c3dda64c4eed4d257661a9c07d325f076c49f798d9b18a1730fR1-R61)

**Benchmark code simplification:**

* Removed unnecessary dependencies such as `fake`, `rand`, and related batching logic, resulting in cleaner and more maintainable benchmark code. [[1]](diffhunk://#diff-0ab594c0325c3dff69fcf669d4434fdfc89aa59f812d6ae725e85e8916894749R1-L46) [[2]](diffhunk://#diff-f36f0527c47b86bcaf33bf9e4101e8323a146fc31973f9f54855f174690f0f8fR1-R57) [[3]](diffhunk://#diff-caebd835984e8bfd468406b44a4516dae63f4cd0fba25e34537032d02a2033a4R1-R40) [[4]](diffhunk://#diff-d18135f34714079f23c094b04ce36e9b8480fbc62817e14b83f3eb3b7437c920R1-R26)
* Refactored the benchmarks to use direct iteration and input generation, simplifying the logic for each benchmark case. [[1]](diffhunk://#diff-0ab594c0325c3dff69fcf669d4434fdfc89aa59f812d6ae725e85e8916894749R1-L46) [[2]](diffhunk://#diff-f36f0527c47b86bcaf33bf9e4101e8323a146fc31973f9f54855f174690f0f8fR1-R57) [[3]](diffhunk://#diff-caebd835984e8bfd468406b44a4516dae63f4cd0fba25e34537032d02a2033a4R1-R40) [[4]](diffhunk://#diff-d18135f34714079f23c094b04ce36e9b8480fbc62817e14b83f3eb3b7437c920R1-R26) [[5]](diffhunk://#diff-a16db9296de46c3dda64c4eed4d257661a9c07d325f076c49f798d9b18a1730fR1-R61)

**Benchmark configuration improvements:**

* Increased measurement time and sample size for more reliable results in all benchmarks. [[1]](diffhunk://#diff-0ab594c0325c3dff69fcf669d4434fdfc89aa59f812d6ae725e85e8916894749R1-L46) [[2]](diffhunk://#diff-f36f0527c47b86bcaf33bf9e4101e8323a146fc31973f9f54855f174690f0f8fR1-R57) [[3]](diffhunk://#diff-caebd835984e8bfd468406b44a4516dae63f4cd0fba25e34537032d02a2033a4R1-R40) [[4]](diffhunk://#diff-d18135f34714079f23c094b04ce36e9b8480fbc62817e14b83f3eb3b7437c920R1-R26) [[5]](diffhunk://#diff-a16db9296de46c3dda64c4eed4d257661a9c07d325f076c49f798d9b18a1730fR1-R61)

**Testing improvements:**

* In the test suite, the degree for random polynomial generation is now chosen from a wider range (`0..2_000`), increasing test coverage.

**New benchmark added:**

* Added a new benchmark file `benches/evaluation_proof.rs` to measure the performance of proof generation for polynomial evaluations.